### PR TITLE
Use dracut overlayfs support for the live image writable overlay.

### DIFF
--- a/mklive.sh.in
+++ b/mklive.sh.in
@@ -319,6 +319,7 @@ done
 shift $((OPTIND - 1))
 
 XBPS_REPOSITORY="$XBPS_REPOSITORY --repository=http://repo.voidlinux.eu/current --repository=http://muslrepo.voidlinux.eu/current"
+BOOT_CMDLINE="$BOOT_CMDLINE rd.live.overlay.overlayfs=1 "
 
 ARCH=$(xbps-uhelper arch)
 

--- a/mklive.sh.in
+++ b/mklive.sh.in
@@ -74,7 +74,6 @@ Options:
  -l <locale>        Default locale to use (en_US.UTF-8 if unset).
  -i <lz4|gzip|bzip2|xz> Compression type for the initramfs image (lz4 if unset).
  -s <gzip|bzip2|xz>     Compression type for the squashfs image (xz if unset)
- -S <freesize>      Allocate this free size (MB) for the rootfs.
  -o <file>          Output file name for the ISO image (auto if unset).
  -p "pkg pkgN ..."  Install additional packages into the ISO image.
  -I <includedir>    Include directory structure under given path into rootfs
@@ -258,11 +257,8 @@ generate_squashfs() {
 
     # Find out required size for the rootfs and create an ext3fs image off it.
     ROOTFS_SIZE=$(du -sm "$ROOTFS"|awk '{print $1}')
-    if [ -z "$ROOTFS_FREESIZE" ]; then
-        ROOTFS_FREESIZE="$((ROOTFS_SIZE/6))"
-    fi
     mkdir -p "$BUILDDIR/tmp/LiveOS"
-    truncate -s "$((ROOTFS_SIZE+ROOTFS_FREESIZE))M" \
+    truncate -s "$((ROOTFS_SIZE+ROOTFS_SIZE/6))M" \
 	    $BUILDDIR/tmp/LiveOS/ext3fs.img >/dev/null 2>&1
     mkdir -p "$BUILDDIR/tmp-rootfs"
     mkfs.ext3 -F -m1 "$BUILDDIR/tmp/LiveOS/ext3fs.img" >/dev/null 2>&1
@@ -308,7 +304,6 @@ while getopts "a:b:r:c:C:T:Kk:l:i:I:s:S:o:p:h" opt; do
         i) INITRAMFS_COMPRESSION="$OPTARG";;
         I) INCLUDE_DIRECTORY="$OPTARG";;
         s) SQUASHFS_COMPRESSION="$OPTARG";;
-        S) ROOTFS_FREESIZE="$OPTARG";;
         o) OUTPUT_FILE="$OPTARG";;
         p) PACKAGE_LIST="$OPTARG";;
         C) BOOT_CMDLINE="$OPTARG";;
@@ -319,6 +314,7 @@ done
 shift $((OPTIND - 1))
 
 XBPS_REPOSITORY="$XBPS_REPOSITORY --repository=http://repo.voidlinux.eu/current --repository=http://muslrepo.voidlinux.eu/current"
+# Configure dracut to use overlayfs for the writable overlay.
 BOOT_CMDLINE="$BOOT_CMDLINE rd.live.overlay.overlayfs=1 "
 
 ARCH=$(xbps-uhelper arch)


### PR DESCRIPTION
Currently dracut uses the default way to produce a temporary writable overlay for the live cd. It creates a file in memory and uses dm snapshots. Unfortunately the default size of that file is pretty small by default and can only be increased indirectly with $ROOTFS_FREESIZE [1].
The first patch enables the overlayfs support in dracut, which creates and uses a tmpfs with the same size as the one mounted on /run (50% of available memory). That removes the need to predetermine a "correct"  fixed overlay size that fits every use and provides (in most cases) bigger overlays than the current default, that scales proportionaly to the users RAM and not the image size.
The second patch removes $ROOTFS_FREESIZE.
________________________
[1] Using the default dracut scheme, the overlay size can be directly controlled by having rd.live.overlay.size=<size_MiB>  in the kernel command live. 