### PR TITLE
installer.sh.in: fix check for *-musl arch

### DIFF
--- a/installer.sh.in
+++ b/installer.sh.in
@@ -1360,7 +1360,7 @@ menu() {
         DEFITEM="Keyboard"
     fi
 
-    if xbps-uhelper arch | grep '-musl$' > /dev/null; then
+    if xbps-uhelper arch | grep -qe '-musl$'; then
         DIALOG --default-item $DEFITEM \
             --extra-button --extra-label "Settings" \
             --title " Void Linux installation menu " \


### PR DESCRIPTION
it should work and not print `grep: invalid max count` now

`grep '-musl$'` is the same as as `grep -m 'usl$'`, but `grep -e <pattern>` lets you use patterns starting with a dash

also use `-q` instead of `> dev/null`