### PR TITLE
mklive.sh: Fixed syslinux datadir value after pkg update

### DIFF
--- a/mklive.sh.in
+++ b/mklive.sh.in
@@ -364,7 +364,7 @@ CURRENT_STEP=0
 STEP_COUNT=9
 [ -n "${INCLUDE_DIRECTORY}" ] && ((STEP_COUNT=STEP_COUNT+1))
 
-: ${SYSLINUX_DATADIR:="$VOIDHOSTDIR"/usr/share/syslinux}
+: ${SYSLINUX_DATADIR:="$VOIDHOSTDIR"/usr/lib/syslinux}
 : ${GRUB_DATADIR:="$VOIDHOSTDIR"/usr/share/grub}
 : ${SPLASH_IMAGE:=data/splash.png}
 : ${XBPS_INSTALL_CMD:=xbps-install}


### PR DESCRIPTION
After https://github.com/void-linux/void-packages/pull/7002 the required syslinux files are located in `/usr/lib/syslinux` instead of `/usr/share/syslinux`. Updated the `SYSLINUX_DATADIR` variable to reflect these changes.