### PR TITLE
mklive.sh: remove unused ISO_VOLUME variable.

### DIFF
--- a/mklive.sh.in
+++ b/mklive.sh.in
@@ -346,7 +346,6 @@ fi
 readonly CURDIR="$PWD"  
 
 
-ISO_VOLUME="VOID_LIVE"
 if [ -n "$ROOTDIR" ]; then
     BUILDDIR=$(mktemp --tmpdir="$ROOTDIR" -d)
 else


### PR DESCRIPTION
Issue in old org: https://github.com/voidlinux/void-mklive/issues/164