### PR TITLE
Made mklive be able to run from any dir

### DIFF
--- a/mklive.sh.in
+++ b/mklive.sh.in
@@ -345,8 +345,6 @@ if [ "$(id -u)" -ne 0 ]; then
     die "Must be run as root, exiting..."
 fi
 
-readonly CURDIR="$PWD"  
-
 if ! echo "$OUTPUT_FILE" | grep '^/.*'; then # If -o relative path, make absolute
     OUTPUT_FILE=$(realpath "$RUNDIR/$OUTPUT_FILE")
 fi

--- a/mklive.sh.in
+++ b/mklive.sh.in
@@ -29,6 +29,11 @@
 trap 'error_out $? $LINENO' INT TERM 0
 umask 022
 
+RUNDIR=$(pwd -P)
+SCRIPTDIR=$(realpath $(dirname "$0"))
+
+cd "$SCRIPTDIR"
+
 readonly REQUIRED_PKGS="base-files libgcc dash coreutils sed tar gawk syslinux grub-i386-efi grub-x86_64-efi squashfs-tools xorriso"
 readonly INITRAMFS_PKGS="binutils xz device-mapper dhclient dracut-network"
 readonly PROGNAME=$(basename "$0")
@@ -287,7 +292,7 @@ generate_iso_image() {
         -no-emul-boot -boot-load-size 4 -boot-info-table \
         -eltorito-alt-boot -e boot/grub/efiboot.img -isohybrid-gpt-basdat -no-emul-boot \
         -isohybrid-mbr "$SYSLINUX_DATADIR"/isohdpfx.bin \
-        -output "$CURDIR/$OUTPUT_FILE" "$IMAGEDIR" || die "Failed to generate ISO image"
+        -output "$OUTPUT_FILE" "$IMAGEDIR" || die "Failed to generate ISO image"
 }
 
 #
@@ -342,6 +347,9 @@ fi
 
 readonly CURDIR="$PWD"  
 
+if ! echo "$OUTPUT_FILE" | grep '^/.*'; then # If -o relative path, make absolute
+    OUTPUT_FILE=$(realpath "$RUNDIR/$OUTPUT_FILE")
+fi
 
 if [ -n "$ROOTDIR" ]; then
     BUILDDIR=$(mktemp --tmpdir="$ROOTDIR" -d)
@@ -417,7 +425,5 @@ generate_squashfs
 print_step "Generating ISO image..."
 generate_iso_image
 
-hsize=$(du -sh "$CURDIR/$OUTPUT_FILE"|awk '{print $1}')
-info_msg "Created $(readlink -f "$CURDIR"/"$OUTPUT_FILE") ($hsize) successfully."
-
-
+hsize=$(du -sh "$OUTPUT_FILE"|awk '{print $1}')
+info_msg "Created $(readlink -f "$OUTPUT_FILE") ($hsize) successfully."


### PR DESCRIPTION
Previously the current working directory had to be the repository root for `mklive.sh` to work.

This PR makes it so `mklive.sh` can be run from any directory. Minimal changes were required, `mklive.sh` simply `cd`s into the repository root before running the rest of its commands. Making it seem like it was invoked inside the repository root in the first place.

Additionally makes the `-o` option work with relative and absolute paths. So you can save `.iso` files in other locations besides the repository root.