### PR TITLE
Build Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ This repository contains utilities for Void Linux:
  * mkrootfs  (The Void Linux rootfs maker for ARM platforms)
  * mknet (Script to generate netboot tarballs for Void)
 
-#### Dependencies
+#### Build Dependencies
+ * make
 
+#### Dependencies
  * xbps>=0.45
  * qemu-user-static binaries (for mkrootfs)
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This repository contains utilities for Void Linux:
  * make
 
 #### Dependencies
+ * Compression type for the initramfs image
+   * liblz4 (for lz4, xz) (default)
  * xbps>=0.45
  * qemu-user-static binaries (for mkrootfs)
 


### PR DESCRIPTION
Should mark make as a build dependency, as it's not in the base system