### PR TITLE
installer: new timezone menu

### DIFF
--- a/installer.sh.in
+++ b/installer.sh.in
@@ -577,22 +577,22 @@ set_locale() {
 }
 
 menu_timezone() {
-    local _tzones="$(cd /usr/share/zoneinfo; find Africa/ America/ Antarctica/ Arctic/ Asia/ Atlantic/ Australia/ Europe/ Indian/ Pacific/ posix/ -type f | sort)"
-    local _TIMEZONES=
+    local areas=(Africa America Antarctica Arctic Asia Atlantic Australia Europe Indian Pacific)
 
-    for f in ${_tzones}; do
-        _TIMEZONES="${_TIMEZONES} ${f} -"
-    done
-    while true; do
-        DIALOG --title " Select your timezone " --menu "$MENULABEL" 14 70 14 ${_TIMEZONES}
-        if [ $? -eq 0 ]; then
-            set_option TIMEZONE "$(cat $ANSWER)"
+    local area locations location
+    while (IFS='|'; DIALOG ${area:+--default-item|"$area"} --title " Select area " --menu "$MENULABEL" 19 51 19 $(printf '%s||' "${areas[@]}")); do
+        area=$(cat $ANSWER)
+        read -a locations -d '\n' < <(find /usr/share/zoneinfo/$area -type f -printf '%P\n' | sort)
+        if (IFS='|'; DIALOG --title " Select location (${area}) " --menu "$MENULABEL" 19 51 19 $(printf '%s||' "${locations[@]//_/ }")); then
+            location=$(tr ' ' '_' < $ANSWER)
+            set_option TIMEZONE "$area/$location"
             TIMEZONE_DONE=1
-            break
+            return 0
         else
-            return
+            continue
         fi
     done
+    return 1
 }
 
 set_timezone() {

--- a/installer.sh.in
+++ b/installer.sh.in
@@ -1425,7 +1425,7 @@ menu() {
     esac
 }
 
-if [ ! -x /bin/dialog ]; then
+if ! command -v dialog >/dev/null; then
     echo "ERROR: missing dialog command, exiting..."
     exit 1
 fi


### PR DESCRIPTION
the old one was a flat list of too many timezones, but this one makes you choose an [area](https://en.wikipedia.org/wiki/Zoneinfo#Names_of_time_zones) first

old one (after scrolling past ~852 timezones with 6 visible at once):

![old 1](https://user-images.githubusercontent.com/41114783/56883191-9cbba200-6a6e-11e9-9487-dcad8cae1cc1.png)

new one:

![new 1](https://user-images.githubusercontent.com/41114783/56883197-a1805600-6a6e-11e9-9d57-9c6132039f73.png)
![new 2](https://user-images.githubusercontent.com/41114783/56883198-a218ec80-6a6e-11e9-9d94-f9fdd7428f33.png)
![new 3](https://user-images.githubusercontent.com/41114783/56883202-a2b18300-6a6e-11e9-86af-307f3dc3e3c9.png)