### PR TITLE
Add  /bin/dash as a default command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,3 +32,5 @@ FROM scratch
 COPY --from=stage1 /target /
 RUN xbps-reconfigure -a && \
   rm -r /var/cache/xbps
+
+CMD ["/bin/sh"]


### PR DESCRIPTION
fix the error when no run command is specified:

```sh
$ docker run -it voidlinux/voidlinux-musl
docker: Error response from daemon: No command specified.
See 'docker run --help'.
```