### PR TITLE
build-x86-images.sh: remove intel-ucode from X_PKGS

### DIFF
--- a/build-x86-images.sh.in
+++ b/build-x86-images.sh.in
@@ -29,7 +29,7 @@ readonly LXQT_IMG=void-live-${ARCH}-${DATE}-lxqt.iso
 readonly GRUB="grub-i386-efi grub-x86_64-efi"
 
 readonly BASE_PKGS="dialog cryptsetup lvm2 mdadm $GRUB"
-readonly X_PKGS="$BASE_PKGS xorg-minimal xorg-input-drivers xorg-video-drivers setxkbmap xauth font-misc-misc terminus-font dejavu-fonts-ttf alsa-plugins-pulseaudio intel-ucode"
+readonly X_PKGS="$BASE_PKGS xorg-minimal xorg-input-drivers xorg-video-drivers setxkbmap xauth font-misc-misc terminus-font dejavu-fonts-ttf alsa-plugins-pulseaudio"
 readonly E_PKGS="$X_PKGS lxdm enlightenment terminology econnman udisks2 firefox-esr"
 readonly XFCE_PKGS="$X_PKGS lxdm xfce4 gnome-themes-standard gnome-keyring network-manager-applet gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox-esr"
 readonly MATE_PKGS="$X_PKGS lxdm mate mate-extra gnome-keyring network-manager-applet gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox-esr"


### PR DESCRIPTION
intel-ucode went to nonfree repository
with https://github.com/void-linux/void-packages/pull/10865

It makes more sense in permanent installations anyway