### PR TITLE
Increase initial squashfs size reservation

### DIFF
--- a/mklive.sh.in
+++ b/mklive.sh.in
@@ -255,7 +255,7 @@ generate_squashfs() {
     # Find out required size for the rootfs and create an ext3fs image off it.
     ROOTFS_SIZE=$(du -sm "$ROOTFS"|awk '{print $1}')
     mkdir -p "$BUILDDIR/tmp/LiveOS"
-    truncate -s "$((ROOTFS_SIZE+ROOTFS_SIZE/6))M" \
+    truncate -s "$((ROOTFS_SIZE+ROOTFS_SIZE))M" \
 	    "$BUILDDIR"/tmp/LiveOS/ext3fs.img >/dev/null 2>&1
     mkdir -p "$BUILDDIR/tmp-rootfs"
     mkfs.ext3 -F -m1 "$BUILDDIR/tmp/LiveOS/ext3fs.img" >/dev/null 2>&1


### PR DESCRIPTION
To help account for filesystem compression and such (particularly ZFS-on-root with compression enabled), bump the initial size reservation from (7/6) * X to 2 * X
It could probably be a bit lower, but it is probably better to avoid getting too specific to particular compression rates or filesystem optimizations.

Sponsored by: Project Trident