### PR TITLE
Avoid copying qemu-static to rootfs

### DIFF
--- a/lib.sh.in
+++ b/lib.sh.in
@@ -134,11 +134,6 @@ cleanup_chroot() {
 
     # Un-Mount the pseudofs mounts if they were mounted
     umount_pseudofs
-
-    # If a QEMU binary was copied in, remove that as well
-    if [ -x "$ROOTFS/usr/bin/$QEMU_BIN" ] ; then
-        rm "$ROOTFS/usr/bin/$QEMU_BIN"
-    fi
 }
 
 # TODO: Figure out how to register the binfmt for x86_64 and for i686
@@ -232,18 +227,7 @@ register_binfmt() {
 
     # Only register if the map is incomplete
     if [ ! -f /proc/sys/fs/binfmt_misc/qemu-$_cpu ] ; then
-        echo ":qemu-$_cpu:M::$_magic:$_mask:/usr/bin/$QEMU_BIN:" > /proc/sys/fs/binfmt_misc/register 2>/dev/null
-    fi
-
-    # If the static binary isn't in the chroot then the chroot will
-    # fail.  The kernel knows about the map but without the static
-    # version there's no interpreter in the chroot, only the
-    # dynamically linked one in the host.  To simplify things we just
-    # use the static one always and make sure it shows up at the same
-    # place in the host and the chroot.
-    if [ ! -x "$ROOTFS/usr/bin/$QEMU_BIN" ] ; then
-        install -m755 -D "$(which "$QEMU_BIN")" "$ROOTFS/usr/bin/$QEMU_BIN" ||
-            die "Could not install $QEMU_BIN to $ROOTFS/usr/bin/"
+        echo ":qemu-$_cpu:M::$_magic:$_mask:/usr/bin/$QEMU_BIN:F" > /proc/sys/fs/binfmt_misc/register 2>/dev/null
     fi
 }
 


### PR DESCRIPTION
Use fix binary flag (F) to load binfmt interpreter (qemu-static) on
register, so it doesn't need to be copied to chroot.

This requires kernel >= 4.9.