### PR TITLE
Revert "Increase partitions shift on pinebookpro"

### DIFF
--- a/mkimage.sh.in
+++ b/mkimage.sh.in
@@ -165,11 +165,6 @@ if [ "$BOOT_FSTYPE" = "vfat" ]; then
     _args="-I -F16"
 fi
 
-BOOT_START=2048
-case "$PLATFORM" in
-    pinebookpro*) BOOT_START=32768 ;;
-esac
-
 case "$PLATFORM" in
     cubieboard2|cubietruck|ci20*|odroid-c2*)
         # These platforms use a single partition for the entire filesystem.
@@ -189,8 +184,8 @@ _EOF
         # layout for new platforms.
         sfdisk "${FILENAME}" <<_EOF
 label: dos
-${BOOT_START},${BOOT_FSSIZE},b,*
-+${BOOT_FSSIZE},+,L
+2048,${BOOT_FSSIZE},b,*
+,+,L
 _EOF
         LOOPDEV=$(losetup --show --find --partscan "$FILENAME")
         # Normally we need to quote to prevent argument splitting, but


### PR DESCRIPTION
Reverts void-linux/void-mklive#115

It looks like it broke partition table creation on other platforms.
