### PR TITLE
Postpone package configuration

### DIFF
--- a/mkplatformfs.sh.in
+++ b/mkplatformfs.sh.in
@@ -160,7 +160,7 @@ tar xf "$BASE_TARBALL" -C "$ROOTFS"
 # $PKGS.  After this step we will do an xbps-reconfigure -f $PKGS
 # under the correct architecture to ensure the system is setup
 # correctly.
-run_cmd_target "xbps-install -S $XBPS_CONFFILE $XBPS_CACHEDIR $XBPS_REPOSITORY -r $ROOTFS -y $PKGS"
+run_cmd_target "xbps-install -SU $XBPS_CONFFILE $XBPS_CACHEDIR $XBPS_REPOSITORY -r $ROOTFS -y $PKGS"
 
 # Now that the packages are installed, we need to chroot in and
 # reconfigure.  This needs to be done as the right architecture.

--- a/mkrootfs.sh.in
+++ b/mkrootfs.sh.in
@@ -146,7 +146,7 @@ mount_pseudofs
 # system package into the rootfs.  This will not produce a
 # bootable system but will instead produce a base component that can
 # be quickly expanded to perform other actions on.
-run_cmd_target "xbps-install -S $XBPS_CONFFILE $XBPS_CACHEDIR $XBPS_REPOSITORY -r $ROOTFS -y $SYSPKG"
+run_cmd_target "xbps-install -SU $XBPS_CONFFILE $XBPS_CACHEDIR $XBPS_REPOSITORY -r $ROOTFS -y $SYSPKG"
 
 # Enable en_US.UTF-8 locale and generate it into the target ROOTFS.
 # This is a bit of a hack since some glibc stuff doesn't really work


### PR DESCRIPTION
Instruct xbps-install to do unpack only, so packages can be properly
configured by xbps-reconfigure call.

Before, xbps-install was sometimes marking packages as configured,
thus making xbps-reconfigure call useless.