### PR TITLE
Dockerfile: remove spdx-licenses-list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ FROM scratch as stage1
 ARG REPOSITORY=https://alpha.de.repo.voidlinux.org
 ARG ARCH=x86_64
 ARG BASEPKG=base-minimal
-ARG ADDINS=
 COPY --from=stage0 /target /
 COPY keys/* /target/var/db/xbps/keys/
 RUN xbps-reconfigure -a && \
@@ -26,7 +25,7 @@ RUN xbps-reconfigure -a && \
     --repository=${REPOSITORY}/current \
     --repository=${REPOSITORY}/current/musl \
     -r /target \
-    ${BASEPKG} ${ADDINS}
+    ${BASEPKG}
 
 # 3) configure and clean up the final image
 FROM scratch

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,6 @@ masterdir-all-print:
 masterdir-all: $(ALL_MASTERDIRS)
 
 masterdir-%:
-	$(SUDO) docker build --build-arg REPOSITORY=$(XBPS_REPOSITORY) --build-arg ARCH=$* --build-arg ADDINS=spdx-licenses-list -t voidlinux/masterdir-$*:$(DATECODE) .
+	$(SUDO) docker build --build-arg REPOSITORY=$(XBPS_REPOSITORY) --build-arg ARCH=$* -t voidlinux/masterdir-$*:$(DATECODE) .
 
 .PHONY: clean dist rootfs-all-print rootfs-all platformfs-all-print platformfs-all pxe-all-print pxe-all masterdir-all-print masterdir-all masterdir-push-all


### PR DESCRIPTION
Including a copy in void-packages turned out better solution.
Grep in image don't have required perl regexps, and getting
one that have make linting slower by order of magnitude.
Even if it was already there, simply using image is
unnecessarily slower.

This reverts commit 163a923529da258d838ac6cf355aa98f3ed7b6d6.