### PR TITLE
README.md: remove (presumably dated) reference to runit

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ and then see the usage output:
 
 #### Examples
 
-Build a native live image with runit and keyboard set to 'fr':
+Build a native live image keyboard set to 'fr':
 
     # ./mklive.sh -k fr
 


### PR DESCRIPTION
I'm assuming this was written in a transitional phase between systemd and runit?