### PR TITLE
WIP: Add development Dockerfile

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -5,5 +5,5 @@ FROM voidlinux/voidlinux:latest
 COPY . /scripts
 WORKDIR /scripts
 
-RUN xbps-install -Sy make git bash
+RUN xbps-install -Sy make git bash kmod
 RUN make

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,0 +1,9 @@
+# Use this Dockerfile to test the scripts in a safe environment.
+
+FROM voidlinux/voidlinux:latest
+
+COPY . /scripts
+WORKDIR /scripts
+
+RUN xbps-install -Sy make git bash
+RUN make

--- a/mkplatformfs.sh.in
+++ b/mkplatformfs.sh.in
@@ -187,7 +187,7 @@ if [ ! -f "$ROOTFS/boot/uInitrd" ] ||
     # initrd so that it can install the kernel drivers in it.  Normally
     # this check is quite complex, but since this is a clean rootfs and we
     # just installed exactly one kernel, this check can get by with a
-    # really niave command to figure out the kernel version
+    # really naive command to figure out the kernel version
     KERNELVERSION=$(ls "$ROOTFS/usr/lib/modules/")
 
     # Some platforms also have special arguments that need to be set


### PR DESCRIPTION
The goal of this PR is to allow builds running inside Docker in development.

Advantages:

* People who aren't using Void can build Void live images/rootfs
* It's safer since you don't have to give the script root access to your machine