### PR TITLE
Add support for split rpi kernel variants and rpi4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ SCRIPTS += $(SHIN:.sh.in=.sh)
 DATECODE=$(shell date "+%Y%m%d")
 SHELL=/bin/bash
 
-T_PLATFORMS=rpi{,2,3}{,-musl} beaglebone{,-musl} cubieboard2{,-musl} odroid-c2{,-musl} GCP{,-musl} pinebookpro{,-musl}
+T_PLATFORMS=rpi{,2,3,4}{,-musl} beaglebone{,-musl} cubieboard2{,-musl} odroid-c2{,-musl} GCP{,-musl} pinebookpro{,-musl}
 T_ARCHS=i686 x86_64{,-musl} armv{6,7}l{,-musl} aarch64{,-musl}
 
-T_SBC_IMGS=rpi{,2,3}{,-musl} beaglebone{,-musl} cubieboard2{,-musl} odroid-c2{,-musl} pinebookpro{,-musl}
+T_SBC_IMGS=rpi{,2,3,4}{,-musl} beaglebone{,-musl} cubieboard2{,-musl} odroid-c2{,-musl} pinebookpro{,-musl}
 T_CLOUD_IMGS=GCP{,-musl}
 
 T_PXE_ARCHS=x86_64{,-musl}

--- a/lib.sh.in
+++ b/lib.sh.in
@@ -287,6 +287,7 @@ set_target_arch_from_platform() {
         cubieboard2*|cubietruck*) XBPS_TARGET_ARCH="armv7l";;
         odroid-u2*) XBPS_TARGET_ARCH="armv7l";;
         odroid-c2*) XBPS_TARGET_ARCH="aarch64";;
+        rpi4*) XBPS_TARGET_ARCH="aarch64";;
         rpi3*) XBPS_TARGET_ARCH="aarch64";;
         rpi2*) XBPS_TARGET_ARCH="armv7l";;
         rpi*) XBPS_TARGET_ARCH="armv6l";;

--- a/mkimage.sh.in
+++ b/mkimage.sh.in
@@ -143,7 +143,7 @@ fi
 
 # Be absolutely certain the platform is supported before continuing
 case "$PLATFORM" in
-    bananapi|beaglebone|cubieboard2|cubietruck|odroid-c2|odroid-u2|rpi|rpi2|rpi3|GCP|pinebookpro|pinephone|*-musl);;
+    bananapi|beaglebone|cubieboard2|cubietruck|odroid-c2|odroid-u2|rpi|rpi2|rpi3|rpi4|GCP|pinebookpro|pinephone|*-musl);;
     *) die "The $PLATFORM is not supported, exiting..."
 esac
 

--- a/mkplatformfs.sh.in
+++ b/mkplatformfs.sh.in
@@ -50,7 +50,7 @@ Usage: $PROGNAME [options] <platform> <base-tarball>
 
 Supported platforms: i686, x86_64, GCP, bananapi, beaglebone,
                      cubieboard2, cubietruck, odroid-c2, odroid-u2,
-                     rpi, rpi2 (armv7), rpi3 (aarch64), ci20,
+                     rpi, rpi2 (armv7), rpi3 (aarch64), rpi4 (aarch64), ci20,
                      pinebookpro, pinephone
 
 Options
@@ -117,9 +117,10 @@ case "$PLATFORM" in
     cubieboard2*|cubietruck*) PKGS="$BASEPKG ${PLATFORM%-*}-base" ;;
     odroid-u2*) PKGS="$BASEPKG ${PLATFORM%-*}-base" ;;
     odroid-c2*) PKGS="$BASEPKG ${PLATFORM%-musl}-base" ;;
-    rpi3*) PKGS="$BASEPKG rpi-base" ;;
-    rpi2*) PKGS="$BASEPKG rpi-base" ;;
-    rpi*) PKGS="$BASEPKG ${PLATFORM%-*}-base" ;;
+    rpi4*) PKGS="$BASEPKG rpi4-base" ;;
+    rpi3*) PKGS="$BASEPKG rpi3-base" ;;
+    rpi2*) PKGS="$BASEPKG rpi2-base" ;;
+    rpi*) PKGS="$BASEPKG rpi-base" ;;
     ci20*) PKGS="$BASEPKG ${PLATFORM%-*}-base" ;;
     i686*) PKGS="$BASEPKG" ;;
     x86_64*) PKGS="$BASEPKG" ;;

--- a/release.sh.in
+++ b/release.sh.in
@@ -6,8 +6,8 @@ DATECODE=$(date "+%Y%m%d")
 make
 
 ARCHS="$(echo x86_64{,-musl} i686 armv{6,7}l{,-musl} aarch64{,-musl})"
-PLATFORMS="$(echo rpi{,2,3}{,-musl})"
-SBC_IMGS="$(echo rpi{,2,3}{,-musl})"
+PLATFORMS="$(echo rpi{,2,3,4}{,-musl})"
+SBC_IMGS="$(echo rpi{,2,3,4}{,-musl})"
 
 make rootfs-all ARCHS="$ARCHS" REPOSITORY="$REPOSITORY" DATECODE="$DATECODE"
 make platformfs-all PLATFORMS="$PLATFORMS" REPOSITORY="$REPOSITORY" DATECODE="$DATECODE"


### PR DESCRIPTION
This is `[NOMERGE]` until https://github.com/void-linux/void-packages/pull/29139 is merged. 

___

### How to
1. Build packages. see:https://github.com/void-linux/void-packages/pull/29139
2. Build images
```
cd void-mklive
d=$(date '+%Y%m%d')
repo="where/your/binpkgs/are"
make XBPS_REPOSITORY="-r $repo" void-{armv6l,armv7l,aarch64}-musl-ROOTFS-$d.tar.xz void-rpi{,2,3,4}-musl-$d.img.xz
```
