### PR TITLE
Enable and configure wpa_supplicant with dhcpcd

### DIFF
--- a/build-x86-images.sh.in
+++ b/build-x86-images.sh.in
@@ -32,11 +32,11 @@ build_variant() {
 
     case $variant in
         base)
-            SERVICES="$SERVICES dhcpcd acpid"
+            SERVICES="$SERVICES dhcpcd wpa_supplicant acpid"
         ;;
         enlightenment)
             PKGS="$PKGS $XORG_PKGS lxdm enlightenment terminology udisks2 firefox-esr"
-            SERVICES="$SERVICES acpid dhcpcd lxdm dbus polkitd"
+            SERVICES="$SERVICES acpid dhcpcd wpa_supplicant lxdm dbus polkitd"
         ;;
         xfce)
             PKGS="$PKGS $XORG_PKGS lxdm xfce4 gnome-themes-standard gnome-keyring network-manager-applet gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox-esr"
@@ -60,11 +60,11 @@ build_variant() {
         ;;
         lxde)
             PKGS="$PKGS $XORG_PKGS lxde lxdm gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox-esr"
-            SERVICES="$SERVICES acpid dbus dhcpcd lxdm polkitd"
+            SERVICES="$SERVICES acpid dbus dhcpcd wpa_supplicant lxdm polkitd"
         ;;
         lxqt)
             PKGS="$PKGS $XORG_PKGS lxqt lxdm gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox-esr"
-            SERVICES="$SERVICES elogind dbus dhcpcd lxdm polkitd"
+            SERVICES="$SERVICES elogind dbus dhcpcd wpa_supplicant lxdm polkitd"
         ;;
         *)
             >&2 echo "Unknown variant $variant"

--- a/installer.sh.in
+++ b/installer.sh.in
@@ -822,8 +822,8 @@ set_bootloader() {
 }
 
 test_network() {
-    rm -f xtraeme.asc && \
-        xbps-uhelper fetch https://repo-default.voidlinux.org/live/xtraeme.asc >$LOG 2>&1
+    rm -f otime && \
+        xbps-uhelper fetch https://repo-default.voidlinux.org/current/otime >$LOG 2>&1
     if [ $? -eq 0 ]; then
         DIALOG --msgbox "Network is working properly!" ${MSGBOXSIZE}
         NETWORK_DONE=1
@@ -852,19 +852,27 @@ configure_wifi() {
         DIALOG --msgbox "Invalid AP password." ${MSGBOXSIZE}
     fi
 
-    rm -f ${_wpasupconf%.conf}-${dev}.conf
-    cp -f ${_wpasupconf} ${_wpasupconf%.conf}-${dev}.conf
-    if [ "$enc" = "wep" ]; then
-        echo "network={" >> ${_wpasupconf%.conf}-${dev}.conf
-        echo "  ssid=\"$ssid\"" >> ${_wpasupconf%.conf}-${dev}.conf
-        echo "  wep_key0=\"$pass\"" >> ${_wpasupconf%.conf}-${dev}.conf
-        echo "  wep_tx_keyidx=0" >> ${_wpasupconf%.conf}-${dev}.conf
-        echo "  auth_alg=SHARED" >> ${_wpasupconf%.conf}-${dev}.conf
-        echo "}" >> ${_wpasupconf%.conf}-${dev}.conf
+    # reset the configuration to the default, if necessary
+    # otherwise backup the configuration
+    if [ -f ${_wpasupconf}.orig ]; then
+        cp -f ${_wpasupconf}.orig ${_wpasupconf}
     else
-        wpa_passphrase "$ssid" "$pass" >> ${_wpasupconf%.conf}-${dev}.conf
+        cp -f ${_wpasupconf} ${_wpasupconf}.orig
+    fi
+    if [ "$enc" = "wep" ]; then
+        cat << EOF >> ${_wpasupconf}
+network={
+  ssid="$ssid"
+  wep_key0="$pass"
+  wep_tx_keyidx=0
+  auth_alg=SHARED
+}
+EOF
+    else
+        wpa_passphrase "$ssid" "$pass" >> ${_wpasupconf}
     fi
 
+    sv restart wpa_supplicant
     configure_net_dhcp $dev
     return $?
 }
@@ -882,7 +890,7 @@ configure_net() {
 }
 
 iface_setup() {
-    ip addr show dev $1|grep -q 'inet '
+    ip addr show dev $1 | grep -q -e 'inet ' -e 'inet6 '
     return $?
 }
 
@@ -891,13 +899,14 @@ configure_net_dhcp() {
 
     iface_setup $dev
     if [ $? -eq 1 ]; then
-        dhcpcd -t 10 -w -4 -L $dev -e "wpa_supplicant_conf=/etc/wpa_supplicant/wpa_supplicant-${dev}.conf" 2>&1 | tee $LOG | \
+        sv restart dhcpcd 2>&1 | tee $LOG | \
             DIALOG --progressbox "Initializing $dev via DHCP..." ${WIDGET_SIZE}
         if [ $? -ne 0 ]; then
             DIALOG --msgbox "${BOLD}${RED}ERROR:${RESET} failed to run dhcpcd. See $LOG for details." ${MSGBOXSIZE}
             return 1
         fi
-        iface_setup $dev
+        export -f iface_setup
+        timeout 10s bash -c "while true; do iface_setup $dev; sleep 0.25; done"
         if [ $? -eq 1 ]; then
             DIALOG --msgbox "${BOLD}${RED}ERROR:${RESET} DHCP request failed for $dev. Check $LOG for errors." ${MSGBOXSIZE}
             return 1
@@ -1305,15 +1314,14 @@ ${BOLD}Do you want to continue?${RESET}" 20 80 || return
             # network type empty??!!!
             :
         elif [ "$_type" = "dhcp" ]; then
-            if [ -f /etc/wpa_supplicant/wpa_supplicant-${_dev}.conf ]; then
-                cp /etc/wpa_supplicant/wpa_supplicant-${_dev}.conf $TARGETDIR/etc/wpa_supplicant
-                ln -sf /etc/sv/dhcpcd-${_dev} $TARGETDIR/etc/runit/runsvdir/default/dhcpcd-${_dev}
-            else
-                enable_dhcpd
+            if $(echo $_dev|egrep -q "^wl.*" 2>/dev/null); then
+                cp /etc/wpa_supplicant/wpa_supplicant.conf $TARGETDIR/etc/wpa_supplicant
+                ln -sf /etc/sv/wpa_supplicant $TARGETDIR/etc/runit/runsvdir/default/wpa_supplicant
             fi
+            enable_dhcpd
         elif [ -n "$_dev" -a "$_type" = "static" ]; then
             # static IP through dhcpcd.
-            mv $TARGETDIR/etc/dhcpcd.conf $TARGETDIR/etc/dhdpcd.conf.orig
+            mv $TARGETDIR/etc/dhcpcd.conf $TARGETDIR/etc/dhcpcd.conf.orig
             echo "# Static IP configuration set by the void-installer for $_dev." \
                 >$TARGETDIR/etc/dhcpcd.conf
             echo "interface $_dev" >>$TARGETDIR/etc/dhcpcd.conf

--- a/installer.sh.in
+++ b/installer.sh.in
@@ -829,7 +829,11 @@ test_network() {
         NETWORK_DONE=1
         return 1
     fi
-    DIALOG --msgbox "Network is inaccessible, please set it up properly." ${MSGBOXSIZE}
+    if [ "$1" = "nm" ]; then
+        DIALOG --msgbox "Network Manager is enabled but network is inaccessible, please set it up externally with nmcli, nmtui, or the Network Manager tray applet." ${MSGBOXSIZE}
+    else
+        DIALOG --msgbox "Network is inaccessible, please set it up properly." ${MSGBOXSIZE}
+    fi
 }
 
 configure_wifi() {
@@ -956,6 +960,11 @@ configure_net_static() {
 
 menu_network() {
     local dev addr f DEVICES
+
+    if [ -e /var/service/NetworkManager ]; then
+        test_network nm
+        return
+    fi
 
     for f in $(ls /sys/class/net); do
         [ "$f" = "lo" ] && continue


### PR DESCRIPTION
The installer was originally written when the dhcpcd wpa_supplicant hook
was enabled. In early 2019, the hook was disabled and it appears that
the installer has been unable to configure WiFi since then.

To address this, enable the wpa_supplicant service, configure it, and
reload the service when dhcpcd is used for network connectivity.

Closes #5