### PR TITLE
Fix bug in installer.sh.in causing not to connect to wifi

### DIFF
--- a/installer.sh.in
+++ b/installer.sh.in
@@ -883,7 +883,8 @@ configure_net_dhcp() {
 
     iface_setup $dev
     if [ $? -eq 1 ]; then
-        dhcpcd -t 10 -w -4 -L $dev -e "wpa_supplicant_conf=/etc/wpa_supplicant/wpa_supplicant-${dev}.conf" 2>&1 | tee $LOG | \
+	wpa_supplicant -i${dev} -c"wpa_supplicant_conf=/etc/wpa_supplicant/wpa_supplicant-${dev}.conf"
+        dhcpcd -t 10 -w -4  2>&1 | tee $LOG | \
             DIALOG --progressbox "Initializing $dev via DHCP..." ${WIDGET_SIZE}
         if [ $? -ne 0 ]; then
             DIALOG --msgbox "${BOLD}${RED}ERROR:${RESET} failed to run dhcpcd. See $LOG for details." ${MSGBOXSIZE}


### PR DESCRIPTION
1. Removed dhcp hook from dhcpcd as is don't as previously intended (See https://voidlinux.org/news/2019/01/dhcpcd-7.1.0.html).
2. Added manual wpa_supplicant command to connect to wifi.

Closes #5