### PR TITLE
du: use --apparent-size to calculate rootfs's size

### DIFF
--- a/mklive.sh.in
+++ b/mklive.sh.in
@@ -253,7 +253,7 @@ generate_squashfs() {
     umount_pseudofs
 
     # Find out required size for the rootfs and create an ext3fs image off it.
-    ROOTFS_SIZE=$(du -sm "$ROOTFS"|awk '{print $1}')
+    ROOTFS_SIZE=$(du --apparent-size -sm "$ROOTFS"|awk '{print $1}')
     mkdir -p "$BUILDDIR/tmp/LiveOS"
     truncate -s "$((ROOTFS_SIZE+ROOTFS_SIZE/6))M" \
 	    "$BUILDDIR"/tmp/LiveOS/ext3fs.img >/dev/null 2>&1


### PR DESCRIPTION
On ZFS (probably btrfs, too) with compression on,
disk usage isn't the same with its real sizes.

Without "--apparent-size", du(1) will report its disk usage
which is way lower than real space needed for squashfs.

Let's ask du to provide the real apparent size for our rootfs.

--apparent-size should be available on both GNU's du (used by Void)
and BSD's du.