### PR TITLE
Add linux-headers to live image

### DIFF
--- a/mknet.sh.in
+++ b/mknet.sh.in
@@ -170,7 +170,7 @@ else
     info_msg "Selecting u-boot bootloader"
     bootloader_pkg=uboot-mkimage
 fi
-run_cmd_target "xbps-install $XBPS_CONFFILE $XBPS_CACHEDIR $XBPS_REPOSITORY -r $ROOTFS -Sy ${KERNELPKG-linux} dracut binutils dracut-network dialog ${INITRAMFS_COMPRESSION-xz} ${bootloader_pkg}"
+run_cmd_target "xbps-install $XBPS_CONFFILE $XBPS_CACHEDIR $XBPS_REPOSITORY -r $ROOTFS -Sy ${KERNELPKG-linux} ${KERNELPKG-linux}-headers dracut binutils dracut-network dialog ${INITRAMFS_COMPRESSION-xz} ${bootloader_pkg}"
 run_cmd_chroot "$ROOTFS" "xbps-reconfigure -a"
 
 # Dracut needs to know the kernel version that will be using this


### PR DESCRIPTION
This solves dependency problems of building kernel modules in a live environment.

Attempt to use ZFS in live environment:
- Kernel version of live image is older than in repo
- Building ZFS kernel module requires `linux-headers`
- `linux-headers` depends on newer kernel, requiring a kernel update
- Kernel update is not possible in live environment

Closes #178.

Signed-off-by: Maurice Zhou <ja@apvc.uk>