### PR TITLE
Check QEMU_BIN is not empty for cleanup_chroot

### DIFF
--- a/lib.sh.in
+++ b/lib.sh.in
@@ -136,7 +136,7 @@ cleanup_chroot() {
     umount_pseudofs
 
     # If a QEMU binary was copied in, remove that as well
-    if [ -x "$ROOTFS/usr/bin/$QEMU_BIN" ] ; then
+    if [ -n "$QEMU_BIN" ] && [ -x "$ROOTFS/usr/bin/$QEMU_BIN" ] ; then
         rm "$ROOTFS/usr/bin/$QEMU_BIN"
     fi
 }


### PR DESCRIPTION
when building for same arch, QEMU_BIN would not be set, the condition fallsback to /usr/bin, which is executable.
rm would throw /usr/bin not empty error without causing real harm. But still nicer to handle it more gracefully.