### PR TITLE
Remove agetty services for missing devices

### DIFF
--- a/installer.sh.in
+++ b/installer.sh.in
@@ -1328,6 +1328,13 @@ ${BOLD}Do you want to continue?${RESET}" 20 80 || return
     # clean up polkit rule - it's only useful in live systems
     rm -f $TARGETDIR/etc/polkit-1/rules.d/void-live.rules
 
+    # remove agetty services for devices that are not present
+    for service in /var/service/agetty-*; do
+        if [ ! -e /dev/"$(cut -d'-' -f2 <<< "$service")" ]; then
+            rm -v "$service"
+        fi
+    done
+
     # enable text console for grub if chosen
     if [ "$(get_option TEXTCONSOLE)" = "1" ]; then
         sed -i $TARGETDIR/etc/default/grub \


### PR DESCRIPTION
The most common offenders are agetty-hvsi0 and agetty-hvc0. agetty
services started for devices that do not exist end up failing with

cannot open as standard input: No such file or directory

runit restarts such services resulting in syslog being flooded
with error messages.

Closes #193

---
A "test case":

```
$ ls /var/service | grep agetty
agetty-hvc0
agetty-hvsi0
agetty-tty1
agetty-tty2
agetty-tty3
agetty-tty4
agetty-tty5
agetty-tty6

$ cat /tmp/agetty
#!/bin/bash
set -euo pipefail

for service in /var/service/agetty-*; do
    if [ ! -e /dev/"$(cut -d'-' -f2 <<< "$service")" ]; then
        rm -v "$service"
    fi
done

$ sudo /tmp/agetty
removed '/var/service/agetty-hvc0'
removed '/var/service/agetty-hvsi0'

$ ls /var/service/ | grep agetty
agetty-tty1
agetty-tty2
agetty-tty3
agetty-tty4
agetty-tty5
agetty-tty6
```
Note that I only verified the snipped outside of the installer. If you think it makes sense to test it as a part of the installation process, I can do that too.