### PR TITLE
Fix live.autologin

### DIFF
--- a/dracut/vmklive/adduser.sh
+++ b/dracut/vmklive/adduser.sh
@@ -52,5 +52,5 @@ _EOF
 fi
 
 if [ -n "$AUTOLOGIN" ]; then
-        sed -i "s,GETTY_ARGS=\"--noclear\",GETTY_ARGS=\"--noclear -a $USERNAME\",g" ${NEWROOT}/etc/sv/agetty-tty1/run
+        sed -i "s,GETTY_ARGS=\"--noclear\",GETTY_ARGS=\"--noclear -a $USERNAME\",g" ${NEWROOT}/etc/sv/agetty-tty1/conf
 fi


### PR DESCRIPTION
I think using `agetty-tty1/run` is a mistake, it does not work. After I have changed it to `agetty-tty1/conf`, it worked perfectly fine in the live image. So, I think this is the intended file!