### PR TITLE
Change freenode.org to libera.chat

### DIFF
--- a/installer.sh.in
+++ b/installer.sh.in
@@ -1462,7 +1462,7 @@ Welcome to the Void Linux installation. A simple and minimal \
 Linux distribution made from scratch and built from the source package tree \
 available for XBPS, a new alternative binary package system.\n\n
 The installation should be pretty straightforward. If you are in trouble \
-please join us at ${BOLD}#voidlinux${RESET} on ${BOLD}irc.freenode.org${RESET}.\n\n
+please join us at ${BOLD}#voidlinux${RESET} on ${BOLD}irc.libera.chat${RESET}.\n\n
 ${BOLD}https://www.voidlinux.org${RESET}\n\n" 16 80
 
 while true; do


### PR DESCRIPTION
The Void Linux team has switched its IRC network to libera.chat