### PR TITLE
Fully remove unused -S option

### DIFF
--- a/mklive.sh.in
+++ b/mklive.sh.in
@@ -282,7 +282,7 @@ generate_iso_image() {
 #
 # main()
 #
-while getopts "a:b:r:c:C:T:Kk:l:i:I:s:S:o:p:v:h" opt; do
+while getopts "a:b:r:c:C:T:Kk:l:i:I:s:o:p:v:h" opt; do
     case $opt in
         a) BASE_ARCH="$OPTARG";;
         b) BASE_SYSTEM_PKG="$OPTARG";;
@@ -294,7 +294,6 @@ while getopts "a:b:r:c:C:T:Kk:l:i:I:s:S:o:p:v:h" opt; do
         i) INITRAMFS_COMPRESSION="$OPTARG";;
         I) INCLUDE_DIRECTORY="$OPTARG";;
         s) SQUASHFS_COMPRESSION="$OPTARG";;
-        S) ROOTFS_FREESIZE="$OPTARG";;
         o) OUTPUT_FILE="$OPTARG";;
         p) PACKAGE_LIST="$OPTARG";;
         C) BOOT_CMDLINE="$OPTARG";;


### PR DESCRIPTION
There are some leftovers from [now unused](https://github.com/void-linux/void-mklive/commit/77442599ced04717673e129c98ce07a015fd6bdd) [`-S`](https://github.com/void-linux/void-mklive/commit/7d89972c5756677c62d02d5f4030a97029188c0e) option. This removes the `-S` option form `getopt`.