### PR TITLE
installer.sh: set fs_passno to 0 for btrfs and xfs

### DIFF
--- a/installer.sh.in
+++ b/installer.sh.in
@@ -1067,7 +1067,7 @@ failed to mount $dev on ${mntpt}! check $LOG for errors." ${MSGBOXSIZE}
         fi
         # Add entry to target fstab
         uuid=$(blkid -o value -s UUID "$dev")
-        if [ "$fstype" = "f2fs" ]; then
+        if [ "$fstype" = "f2fs" -o "$fstype" = "btrfs" -o "$fstype" = "xfs" ]; then
             fspassno=0
         else
             fspassno=1
@@ -1092,7 +1092,12 @@ failed to mount $dev on $mntpt! check $LOG for errors." ${MSGBOXSIZE}
         fi
         # Add entry to target fstab
         uuid=$(blkid -o value -s UUID "$dev")
-        echo "UUID=$uuid $mntpt $fstype defaults 0 2" >>$TARGET_FSTAB
+        if [ "$fstype" = "f2fs" -o "$fstype" = "btrfs" -o "$fstype" = "xfs" ]; then
+            fspassno=0
+        else
+            fspassno=2
+        fi
+        echo "UUID=$uuid $mntpt $fstype defaults 0 $fspassno" >>$TARGET_FSTAB
     done
 }
 


### PR DESCRIPTION
For f2fs, set fs_passno also to 0 if not a root filesystem. For btrfs
and xfs, set fs_passno to 0 in all cases. See fsck.btrfs(8) and
fsck.xfs(8) for more information. f2fs still seems to have issues [0].

[0] https://wiki.archlinux.org/title/F2fs#Known_issues