### PR TITLE
use mount --rbind to propagate mounts into the chroot

### DIFF
--- a/dracut/autoinstaller/install.sh
+++ b/dracut/autoinstaller/install.sh
@@ -74,8 +74,8 @@ VAI_install_base_system() {
 VAI_prepare_chroot() {
     # Mount dev, bind, proc, etc into chroot
     mount -t proc proc "${target}/proc"
-    mount -t sysfs sys "${target}/sys"
-    mount -o rbind /dev "${target}/dev"
+    mount --rbind /sys "${target}/sys"
+    mount --rbind /dev "${target}/dev"
 }
 
 VAI_configure_sudo() {

--- a/installer.sh.in
+++ b/installer.sh.in
@@ -1100,7 +1100,7 @@ mount_filesystems() {
     for f in sys proc dev; do
         [ ! -d $TARGETDIR/$f ] && mkdir $TARGETDIR/$f
         echo "Mounting $TARGETDIR/$f..." >$LOG
-        mount --bind /$f $TARGETDIR/$f >$LOG 2>&1
+        mount --rbind /$f $TARGETDIR/$f >$LOG 2>&1
     done
 }
 

--- a/lib.sh.in
+++ b/lib.sh.in
@@ -82,7 +82,7 @@ mount_pseudofs() {
             # pseudofs isn't already mounted.  If it already is then
             # this is virtually impossible to troubleshoot because it
             # looks like the subsequent umount just isn't working.
-            mount -r --bind /$f "$ROOTFS/$f"
+            mount -r --rbind /$f "$ROOTFS/$f"
         fi
     done
     if ! mountpoint -q "$ROOTFS/tmp" ; then

--- a/mklive.sh.in
+++ b/mklive.sh.in
@@ -47,7 +47,7 @@ print_step() {
 mount_pseudofs() {
     for f in sys dev proc; do
         mkdir -p "$ROOTFS"/$f
-        mount --bind /$f "$ROOTFS"/$f
+        mount --rbind /$f "$ROOTFS"/$f
     done
 }
 umount_pseudofs() {


### PR DESCRIPTION
Else things like efivarfs will not be passed down into the chroot,
which makes installing grub fail.

Closes #231.