### PR TITLE
installer: ensure efivarfs is mounted.

### DIFF
--- a/installer.sh.in
+++ b/installer.sh.in
@@ -66,6 +66,9 @@ if [ -e /sys/firmware/efi/systab ]; then
     else
         EFI_TARGET=x86_64-efi
     fi
+    # efivarfs may already have been mounted by elogind.
+    mountpoint -q /sys/firmware/efi/efivars \
+        || mount -t efivarfs efivarfs /sys/firmware/efi/efivars
 fi
 
 # dialog colors


### PR DESCRIPTION
I noticed that #231 and #232 don't work when using the "base" image or "lxde".

Turns out that efivarfs is mounted by elogind (not kidding :-) ). (https://github.com/elogind/elogind/blob/main/src/shared/mount-setup.c#L115)

This patch mounts efivarfs even if elogind is not running.
