### PR TITLE
Fixed bug in networking prompt

### DIFF
--- a/installer.sh.in
+++ b/installer.sh.in
@@ -831,8 +831,8 @@ configure_wifi() {
         "SSID:" 1 1 "" 1 16 30 0 \
         "Encryption:" 2 1 "" 2 16 4 3 \
         "Password:" 3 1 "" 3 16 63 0 || return 1
-    set -- $(cat $ANSWER)
-    ssid="$1"; enc="$2"; pass="$3";
+    readarray -t values <<<$(cat $ANSWER)
+    ssid="${values[0]}"; enc="${values[1]}"; pass="${values[2]}"
 
     if [ -z "$ssid" ]; then
         DIALOG --msgbox "Invalid SSID." ${MSGBOXSIZE}


### PR DESCRIPTION
In the networking prompt of the installer (where you set up wireless networking by configuring the ssid, encryption and password), you weren't able to use a ssid that contains spaces, since the everything after the space would be taken as the encryption method.
Fixed by reading the values, which originally are separated by newlines, into an array and then just reading the single values from that array.