### PR TITLE
Add import & export functionality for settings

### DIFF
--- a/installer.sh.in
+++ b/installer.sh.in
@@ -1340,6 +1340,13 @@ ${BOLD}Do you want to continue?${RESET}" 20 80 || return
 
     # install bootloader.
     set_bootloader
+
+    # execute postinstall script.
+    POSTINSTALL=$(get_option POSTINSTALL)
+    if [ -n "$POSTINSTALL" ]; then
+        source "$POSTINSTALL"
+    fi
+
     sync && sync && sync
 
     # unmount all filesystems.

--- a/installer.sh.in
+++ b/installer.sh.in
@@ -40,6 +40,8 @@ BOOTLOADER_DONE=
 PARTITIONS_DONE=
 NETWORK_DONE=
 FILESYSTEMS_DONE=
+IMPORT_DONE=
+EXPORT_DONE=
 
 TARGETDIR=/mnt/target
 LOG=/dev/tty8
@@ -816,6 +818,7 @@ set_bootloader() {
 test_network() {
     rm -f xtraeme.asc && \
         xbps-uhelper fetch http://alpha.de.repo.voidlinux.org/live/xtraeme.asc >$LOG 2>&1
+
     if [ $? -eq 0 ]; then
         DIALOG --msgbox "Network is working properly!" ${MSGBOXSIZE}
         NETWORK_DONE=1
@@ -1371,6 +1374,36 @@ menu_source() {
     set_option SOURCE $src
 }
 
+menu_import() {
+    local _preset=""
+
+    DIALOG --inputbox "Enter a path to the configuration file:" \
+            ${INPUTSIZE} "$_preset"
+    if [ $? -eq 0 ]; then
+        cat "$(cat $ANSWER)" > "$CONF_FILE"
+
+        IMPORT_DONE=1
+        break
+    else
+        return
+    fi
+}
+
+menu_export() {
+    local _preset="$HOME/void-installer.conf"
+
+    DIALOG --inputbox "Enter a file where settings will be stored:" \
+            ${INPUTSIZE} "$_preset"
+    if [ $? -eq 0 ]; then
+        cat "$CONF_FILE" > "$(cat $ANSWER)"
+
+        EXPORT_DONE=1
+        break
+    else
+        return
+    fi
+}
+
 menu() {
     local AFTER_HOSTNAME
     if [ -z "$DEFITEM" ]; then
@@ -1383,6 +1416,7 @@ menu() {
             --extra-button --extra-label "Settings" \
             --title " Void Linux installation menu " \
             --menu "$MENULABEL" 10 70 0 \
+            "Import" "Import settings from a configuration file" \
             "Keyboard" "Set system keyboard" \
             "Network" "Set up the network" \
             "Source" "Set source installation" \
@@ -1393,6 +1427,7 @@ menu() {
             "BootLoader" "Set disk to install bootloader" \
             "Partition" "Partition disk(s)" \
             "Filesystems" "Configure filesystems and mount points" \
+            "Export" "Export current settings to a file" \
             "Install" "Start installation with saved settings" \
             "Exit" "Exit installation"
     else
@@ -1401,6 +1436,7 @@ menu() {
             --extra-button --extra-label "Settings" \
             --title " Void Linux installation menu " \
             --menu "$MENULABEL" 10 70 0 \
+            "Import" "Import settings from a configuration file" \
             "Keyboard" "Set system keyboard" \
             "Network" "Set up the network" \
             "Source" "Set source installation" \
@@ -1412,6 +1448,7 @@ menu() {
             "BootLoader" "Set disk to install bootloader" \
             "Partition" "Partition disk(s)" \
             "Filesystems" "Configure filesystems and mount points" \
+            "Export" "Export current settings to a file" \
             "Install" "Start installation with saved settings" \
             "Exit" "Exit installation"
     fi
@@ -1426,6 +1463,7 @@ menu() {
     fi
 
     case $(cat $ANSWER) in
+        "Import") menu_import && [ -n "$IMPORT_DONE" ] && DEFITEM="Install";;
         "Keyboard") menu_keymap && [ -n "$KEYBOARD_DONE" ] && DEFITEM="Network";;
         "Network") menu_network && [ -n "$NETWORK_DONE" ] && DEFITEM="Source";;
         "Source") menu_source && [ -n "$SOURCE_DONE" ] && DEFITEM="Hostname";;
@@ -1437,7 +1475,8 @@ menu() {
                && DEFITEM="BootLoader";;
         "BootLoader") menu_bootloader && [ -n "$BOOTLOADER_DONE" ] && DEFITEM="Partition";;
         "Partition") menu_partitions && [ -n "$PARTITIONS_DONE" ] && DEFITEM="Filesystems";;
-        "Filesystems") menu_filesystems && [ -n "$FILESYSTEMS_DONE" ] && DEFITEM="Install";;
+        "Filesystems") menu_filesystems && [ -n "$FILESYSTEMS_DONE" ] && DEFITEM="Export";;
+        "Export") menu_export && [ -n "$EXPORT_DONE" ] && DEFITEM="Install";;
         "Install") menu_install;;
         "Exit") DIE;;
         *) DIALOG --yesno "Abort Installation?" ${YESNOSIZE} && DIE


### PR DESCRIPTION
Hello all together,
here are some more improvements. Don't know if they are wanted by any users but I've had wished they already existed for my purposes.

This request adds an import and export function for the settings, so a user has the ability to load an existing settings configuration for the installation which fits his needs. This is helpful if you have a configuration file, e.g. for VMs or your current environment and you want an easy option to set up your installation quickly without the needs of passing all the menu points.

With this in mind I've added a POSTINSTALL setting, which can be loaded to apply some configuration directly in the install process. This could be helpful if you want to have an easy option to configure your void installation that they fit your needs.
Especially this gives the ability to add other pre-prepared installation scripts later, e.g. to install and configure window managers, desktop environments, only with some additional scripts.

I think this could improve the usability especially for new Linux users. Void is an awesome distribution and I like to see it on more desktops. :D

However, with the current implementation security might be an issue, because the naive implementation of the file storing with root privileges! Just want to know if such a functionality is maybe required by some users.