### PR TITLE
fix: error detection in mkplatformfs

### DIFF
--- a/mkplatformfs.sh.in
+++ b/mkplatformfs.sh.in
@@ -216,7 +216,7 @@ rm -rf "$ROOTFS/var/cache/*" 2>/dev/null
 # Now we can run the POST_CMD script. This user-supplied script gets the
 # $ROOTFS as a parameter.
 if [ -n "$POST_CMD" ]; then
-    info_msg "Running user supllied command: $POST_CMD"
+    info_msg "Running user supplied command: $POST_CMD"
     run_cmd $POST_CMD $ROOTFS
 fi
 
@@ -227,6 +227,7 @@ if [ "$COMPRESSION" = "y" ]; then
     # platform and the date on which the tarball was built.
     tarball=${FILENAME:-void-${PLATFORM}-PLATFORMFS-$(date '+%Y%m%d').tar.xz}
     run_cmd "tar -cp --posix --xattrs -C $ROOTFS . | xz -T${COMPRESSOR_THREADS:-0} -9 > $tarball "
+    [ $? -ne 0 ] && die "Failed to compress tarball"
 
     # Now that we have the tarball we don't need the rootfs anymore, so we
     # can get rid of it.


### PR DESCRIPTION
Sometimes creating the tarball can fail, so check the return code.
