### PR TITLE
[RFC] add minimal set of xtools to live images

### DIFF
--- a/build-x86-images.sh.in
+++ b/build-x86-images.sh.in
@@ -30,7 +30,7 @@ build_variant() {
     fi
     IMG=void-live-${ARCH}-${DATE}${IMG_SUFFIX}.iso
     GRUB_PKGS="grub-i386-efi grub-x86_64-efi"
-    PKGS="dialog cryptsetup lvm2 mdadm void-docs-browse $GRUB_PKGS"
+    PKGS="dialog cryptsetup lvm2 mdadm void-docs-browse xtools-minimal $GRUB_PKGS"
     XORG_PKGS="xorg-minimal xorg-input-drivers xorg-video-drivers setxkbmap xauth font-misc-misc terminus-font dejavu-fonts-ttf alsa-plugins-pulseaudio"
 
     case $variant in

--- a/installer.sh.in
+++ b/installer.sh.in
@@ -1263,7 +1263,7 @@ ${BOLD}Do you want to continue?${RESET}" 20 80 || return
         chroot $TARGETDIR dracut --no-hostonly --add-drivers "ahci" --force >>$LOG 2>&1
         INFOBOX "Removing temporary packages from target ..." 4 60
         echo "Removing temporary packages from target ..." >$LOG
-        xbps-remove -r $TARGETDIR -Ry dialog >>$LOG 2>&1
+        xbps-remove -r $TARGETDIR -Ry dialog xtools-minimal >>$LOG 2>&1
         rmdir $TARGETDIR/mnt/target
     else
         # mount required fs


### PR DESCRIPTION
~~depends on: void-linux/void-packages#37826~~
see also: void-linux/void-docs#688

This will allow for easier chroot installs by way of `xchroot` and other xtools

tested a local install, and ensured that it does not include the package (previously named xtools-live, now named xtools-minimal) in the installed system:

![image](https://user-images.githubusercontent.com/5366828/177065907-7c4e87b5-1cfe-4bbc-a32d-0636de9db5da.png)
![image](https://user-images.githubusercontent.com/5366828/177065935-7e2abec0-b6b6-4b21-adfe-8681e59fa4c5.png)

This addition does not change the total size of the live image at all, because the xtools-live package is only ~25 KB and all dependencies are already in `base-system`

after this is merged and new live images are generated, the chroot install documentation can be updated to use `xchroot`