### PR TITLE
fix: detect current _linux_series

### DIFF
--- a/mklive.sh.in
+++ b/mklive.sh.in
@@ -374,7 +374,7 @@ if [ -n "$LINUX_VERSION" ]; then
     _linux_series="$LINUX_VERSION"
     PACKAGE_LIST="$PACKAGE_LIST $LINUX_VERSION"
 else # Otherwise find latest stable version from linux meta-package
-    _linux_series=$(XBPS_ARCH=$BASE_ARCH $XBPS_QUERY_CMD -r "$ROOTFS" ${XBPS_REPOSITORY:=-R} -x linux|head -1)
+    _linux_series=$(XBPS_ARCH=$BASE_ARCH $XBPS_QUERY_CMD -r "$ROOTFS" ${XBPS_REPOSITORY:=-R} -x linux | grep 'linux[0-9._]\+')
 fi
 
 _kver=$(XBPS_ARCH=$BASE_ARCH $XBPS_QUERY_CMD -r "$ROOTFS" ${XBPS_REPOSITORY:=-R} -p pkgver ${_linux_series})


### PR DESCRIPTION
Fix: https://github.com/void-linux/void-mklive/issues/257

`_linux_series` will detect `linux-base` version if using `head` , it should detect the current `linux` version.

```
~ xbps-query -x linux
linux-base>=0
linux5.18>=0
```

```
~ xbps-query -p pkgname $(xbps-query -x linux|head -1)
linux-base
~ xbps-query -p pkgver $(xbps-query -x linux|head -1)
linux-base-2021.07.21_1
~ xbps-query -p pkgname $(xbps-query -x linux|tail -1)
linux5.18
~ xbps-query -p pkgver $(xbps-query -x linux|tail -1)
linux5.18-5.18.9_1
```