### PR TITLE
build-x86-images: kde: use firefox-esr

### DIFF
--- a/build-x86-images.sh.in
+++ b/build-x86-images.sh.in
@@ -35,7 +35,7 @@ readonly XFCE_PKGS="$X_PKGS lxdm xfce4 gnome-themes-standard gnome-keyring netwo
 readonly MATE_PKGS="$X_PKGS lxdm mate mate-extra gnome-keyring network-manager-applet gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox-esr"
 readonly CINNAMON_PKGS="$X_PKGS lxdm cinnamon gnome-keyring colord gnome-terminal gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox-esr"
 readonly GNOME_PKGS="$X_PKGS gnome firefox-esr"
-readonly KDE_PKGS="$X_PKGS kde5 konsole firefox dolphin"
+readonly KDE_PKGS="$X_PKGS kde5 konsole firefox-esr dolphin"
 readonly LXDE_PKGS="$X_PKGS lxdm lxde gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox-esr"
 readonly LXQT_PKGS="$X_PKGS lxdm lxqt gvfs-afc gvfs-mtp gvfs-smb udisks2 qupzilla"
 


### PR DESCRIPTION
all other versions use firefox-esr, so let's also use it in the kde
image for consistency

firefox was added by @mobinmob in 33f5f5c1fb3513d2846ea637e3218f3f54d0ccd6