### PR TITLE
installer: validate user login name based on useradd(8) rules

### DIFF
--- a/installer.sh.in
+++ b/installer.sh.in
@@ -665,16 +665,24 @@ set_rootpassword() {
 menu_useraccount() {
     local _firstpass _secondpass _desc _again
     local _groups _status _group _checklist
-    local _preset
+    local _preset _userlogin
 
     while true; do
         _preset=$(get_option USERLOGIN)
         [ -z "$_preset" ] && _preset="void"
         DIALOG --inputbox "Enter a primary login name:" ${INPUTSIZE} "$_preset"
         if [ $? -eq 0 ]; then
-            set_option USERLOGIN "$(cat $ANSWER)"
-            USERLOGIN_DONE=1
-            break
+            _userlogin="$(cat $ANSWER)"
+            # based on useradd(8) § Caveats
+            if [ "${#_userlogin}" -le 32 ] && [[ "${_userlogin}" =~ ^[a-z_][a-z0-9_-]*[$]?$ ]]; then
+                set_option USERLOGIN "${_userlogin}"
+                USERLOGIN_DONE=1
+                break
+            else
+                INFOBOX "Invalid login name! Please try again." 6 60
+                unset _userlogin
+                sleep 2 && clear && continue
+            fi
         else
             return
         fi


### PR DESCRIPTION
fixes #256

https://man.voidlinux.org/useradd#CAVEATS

matching documentation update: void-linux/void-docs#689
