### PR TITLE
fix: sed execution for sudoers

### DIFF
--- a/dracut/autoinstaller/install.sh
+++ b/dracut/autoinstaller/install.sh
@@ -80,7 +80,7 @@ VAI_prepare_chroot() {
 
 VAI_configure_sudo() {
     # Give wheel sudo
-    echo "%wheel ALL=(ALL) ALL" > "${target}/etc/sudoers.d/wheel"
+    echo "%wheel ALL=(ALL:ALL) ALL" > "${target}/etc/sudoers.d/wheel"
 }
 
 VAI_correct_root_permissions() {

--- a/dracut/vmklive/adduser.sh
+++ b/dracut/vmklive/adduser.sh
@@ -32,7 +32,7 @@ chroot ${NEWROOT} sh -c "echo "$USERNAME:voidlinux" | chpasswd -c SHA512"
 
 # Enable sudo permission by default.
 if [ -f ${NEWROOT}/etc/sudoers ]; then
-    echo "${USERNAME} ALL=(ALL) NOPASSWD: ALL" >> ${NEWROOT}/etc/sudoers
+    echo "${USERNAME} ALL=(ALL:ALL) NOPASSWD: ALL" > "${NEWROOT}/etc/sudoers.d/99-void-live"
 fi
 
 if [ -d ${NEWROOT}/etc/polkit-1 ]; then

--- a/installer.sh.in
+++ b/installer.sh.in
@@ -1246,7 +1246,7 @@ ${BOLD}Do you want to continue?${RESET}" 20 80 || return
         # Remove live user.
         echo "Removing $USERNAME live user from targetdir ..." >$LOG
         chroot $TARGETDIR userdel -r $USERNAME >$LOG 2>&1
-        sed -i -e "/$USERNAME ALL=.*/d" $TARGETDIR/etc/sudoers
+        rm -f $TARGETDIR/etc/sudoers.d/99-void-live
         TITLE="Check $LOG for details ..."
         INFOBOX "Rebuilding initramfs for target ..." 4 60
         echo "Rebuilding initramfs for target ..." >$LOG
@@ -1311,16 +1311,15 @@ ${BOLD}Do you want to continue?${RESET}" 20 80 || return
         fi
     fi
 
-    if [ -f $TARGETDIR/etc/sudoers ]; then
+    if [ -d $TARGETDIR/etc/sudoers.d ]; then
         USERLOGIN="$(get_option USERLOGIN)"
         if [ -z "$(echo $(get_option USERGROUPS) | grep -w wheel)" -a -n "$USERLOGIN" ]; then
             # enable sudo for primary user USERLOGIN who is not member of wheel
-            echo "# Enable sudo for login '$USERLOGIN'" >> $TARGETDIR/etc/sudoers
-            echo "$USERLOGIN ALL=(ALL) ALL" >> $TARGETDIR/etc/sudoers
+            echo "# Enable sudo for login '$USERLOGIN'" > "$TARGETDIR/etc/sudoers.d/$USERLOGIN"
+            echo "$USERLOGIN ALL=(ALL:ALL) ALL" >> "$TARGETDIR/etc/sudoers.d/$USERLOGIN"
         else
             # enable the sudoers entry for members of group wheel
-            sed -i $TARGETDIR/etc/sudoers \
-                -e "s;#.*%wheel ALL=(ALL) ALL;%wheel ALL=(ALL) ALL;"
+            echo "%wheel ALL=(ALL:ALL) ALL" > "$TARGETDIR/etc/sudoers.d/wheel"
         fi
         unset USERLOGIN
     fi

--- a/packer/scripts/cloud.sh
+++ b/packer/scripts/cloud.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "void ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/99-void
+echo "void ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers.d/99-void
 echo "Defaults:void !requiretty" >> /etc/sudoers.d/99-void
 chmod 0440 /etc/sudoers.d/99-void
 mv /etc/sudoers.d/{,10-}wheel

--- a/packer/scripts/vagrant.sh
+++ b/packer/scripts/vagrant.sh
@@ -3,7 +3,7 @@
 useradd -m -s /bin/bash vagrant
 
 # Set up sudo
-echo '%vagrant ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/vagrant
+echo '%vagrant ALL=(ALL:ALL) NOPASSWD:ALL' > /etc/sudoers.d/vagrant
 echo 'Defaults:vagrant !requiretty' >> /etc/sudoers.d/vagrant
 chmod 0440 /etc/sudoers.d/vagrant
 


### PR DESCRIPTION
`installer.sh.in` sed cannot be executed if using `(ALL)` only, because currently sudoers uses `(ALL:ALL)`.
but I'm not sure that `clouds.sh` and `vagrant.sh` need to be changed too.