### PR TITLE
build-x86-images: rewrite

### DIFF
--- a/build-x86-images.sh.in
+++ b/build-x86-images.sh.in
@@ -1,90 +1,75 @@
 #!/bin/sh
 
-ARCH=
-IMAGE=
+set -eu
+
+ARCH=$(uname -m)
+IMAGES="base enlightenment xfce mate cinnamon gnome kde lxde lxqt"
+REPO=
+DATE=$(date +%Y%m%d)
+
+help() {
+    echo "${0#/*}: [-a arch] [-b base|enlightenment|xfce|mate|cinnamon|gnome|kde|lxde|lxqt] [-r repo]" >&2
+}
 
 while getopts "a:b:hr:" opt; do
 case $opt in
-	a) ARCH="$OPTARG";;
-	b) IMAGE="$OPTARG";;
-	h) echo "${0#/*}: [-a arch] [-b base|e|xfce|mate|cinnamon|gnome|kde|lxde|lxqt] [-r repo]" >&2; exit 1;;
-	r) REPO="-r $OPTARG $REPO";;
+    a) ARCH="$OPTARG";;
+    b) IMAGES="$OPTARG";;
+    h) help; exit 0;;
+    r) REPO="-r $OPTARG $REPO";;
+    *) help; exit 1;;
 esac
 done
 shift $((OPTIND - 1))
 
-: ${ARCH:=$(uname -m)}
+build_variant() {
+    variant="$1"
+    IMG_SUFFIX="-$variant"
+    if [ "$variant" = base ]; then
+        IMG_SUFFIX=
+    fi
+    IMG=void-live-${ARCH}-${DATE}${IMG_SUFFIX}.iso
+    GRUB_PKGS="grub-i386-efi grub-x86_64-efi"
+    PKGS="dialog cryptsetup lvm2 mdadm void-docs-browse $GRUB_PKGS"
+    XORG_PKGS="xorg-minimal xorg-input-drivers xorg-video-drivers setxkbmap xauth font-misc-misc terminus-font dejavu-fonts-ttf alsa-plugins-pulseaudio"
 
-readonly DATE=$(date +%Y%m%d)
-readonly BASE_IMG=void-live-${ARCH}-${DATE}.iso
-readonly E_IMG=void-live-${ARCH}-${DATE}-enlightenment.iso
-readonly XFCE_IMG=void-live-${ARCH}-${DATE}-xfce.iso
-readonly MATE_IMG=void-live-${ARCH}-${DATE}-mate.iso
-readonly CINNAMON_IMG=void-live-${ARCH}-${DATE}-cinnamon.iso
-readonly GNOME_IMG=void-live-${ARCH}-${DATE}-gnome.iso
-readonly KDE_IMG=void-live-${ARCH}-${DATE}-kde.iso
-readonly LXDE_IMG=void-live-${ARCH}-${DATE}-lxde.iso
-readonly LXQT_IMG=void-live-${ARCH}-${DATE}-lxqt.iso
+    case $variant in
+        base) ;;
+        enlightenment)
+            PKGS="$PKGS $XORG_PKGS lxdm enlightenment terminology udisks2 firefox-esr"
+        ;;
+        xfce)
+            PKGS="$PKGS $XORG_PKGS lxdm xfce4 gnome-themes-standard gnome-keyring network-manager-applet gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox-esr"
+        ;;
+        mate)
+            PKGS="$PKGS $XORG_PKGS lxdm mate mate-extra gnome-keyring network-manager-applet gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox-esr"
+        ;;
+        cinnamon)
+            PKGS="$PKGS $XORG_PKGS lxdm cinnamon gnome-keyring colord gnome-terminal gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox-esr"
+        ;;
+        gnome)
+            PKGS="$PKGS $XORG_PKGS gnome firefox-esr"
+        ;;
+        kde)
+            PKGS="$PKGS $XORG_PKGS kde5 konsole firefox-esr dolphin"
+        ;;
+        lxde)
+            PKGS="$PKGS $XORG_PKGS lxde lxdm gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox-esr"
+        ;;
+        lxqt)
+            PKGS="$PKGS $XORG_PKGS lxqt lxdm gvfs-afc gvfs-mtp gvfs-smb udisks2 qupzilla"
+        ;;
+        *)
+            >&2 echo "Unknown variant $variant"
+            exit 1
+        ;;
+    esac
 
-readonly GRUB="grub-i386-efi grub-x86_64-efi"
-
-readonly BASE_PKGS="dialog cryptsetup lvm2 mdadm void-docs-browse $GRUB"
-readonly X_PKGS="$BASE_PKGS xorg-minimal xorg-input-drivers xorg-video-drivers setxkbmap xauth font-misc-misc terminus-font dejavu-fonts-ttf alsa-plugins-pulseaudio"
-readonly E_PKGS="$X_PKGS lxdm enlightenment terminology udisks2 firefox-esr"
-readonly XFCE_PKGS="$X_PKGS lxdm xfce4 gnome-themes-standard gnome-keyring network-manager-applet gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox-esr"
-readonly MATE_PKGS="$X_PKGS lxdm mate mate-extra gnome-keyring network-manager-applet gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox-esr"
-readonly CINNAMON_PKGS="$X_PKGS lxdm cinnamon gnome-keyring colord gnome-terminal gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox-esr"
-readonly GNOME_PKGS="$X_PKGS gnome firefox-esr"
-readonly KDE_PKGS="$X_PKGS kde5 konsole firefox-esr dolphin"
-readonly LXDE_PKGS="$X_PKGS lxdm lxde gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox-esr"
-readonly LXQT_PKGS="$X_PKGS lxdm lxqt gvfs-afc gvfs-mtp gvfs-smb udisks2 qupzilla"
+    ./mklive.sh -a "$ARCH" -o "$IMG" -p "$PKGS" ${REPO} "$@"
+}
 
 [ ! -x mklive.sh ] && exit 0
 
-if [ -z "$IMAGE" -o "$IMAGE" = base ]; then
-	if [ ! -e $BASE_IMG ]; then
-		./mklive.sh -a $ARCH -o $BASE_IMG -p "$BASE_PKGS" ${REPO} "$@"
-	fi
-fi
-if [ -z "$IMAGE" -o "$IMAGE" = e ]; then
-	if [ ! -e $E_IMG ]; then
-		./mklive.sh -a $ARCH -o $E_IMG -p "$E_PKGS" ${REPO} "$@"
-	fi
-fi
-if [ -z "$IMAGE" -o "$IMAGE" = xfce ]; then
-	if [ ! -e $XFCE_IMG ]; then
-		./mklive.sh -a $ARCH -o $XFCE_IMG -p "$XFCE_PKGS" ${REPO} "$@"
-	fi
-fi
-if [ -z "$IMAGE" -o "$IMAGE" = mate ]; then
-	if [ ! -e $MATE_IMG ]; then
-		./mklive.sh -a $ARCH -o $MATE_IMG -p "$MATE_PKGS" ${REPO} "$@"
-	fi
-fi
-if [ -z "$IMAGE" -o "$IMAGE" = cinnamon ]; then
-	if [ ! -e $CINNAMON_IMG ]; then
-		./mklive.sh -a $ARCH -o $CINNAMON_IMG -p "$CINNAMON_PKGS" ${REPO} "$@"
-	fi
-fi
-
-if [ -z "$IMAGE" -o "$IMAGE" = gnome ]; then
-	if [ ! -e $GNOME_IMG ]; then
-		./mklive.sh -a $ARCH -o $GNOME_IMG -p "$GNOME_PKGS" ${REPO} "$@"
-	fi
-fi
-
-if [ -z "$IMAGE" -o "$IMAGE" = lxde ]; then
-	if [ ! -e $LXDE_IMG ]; then
-		./mklive.sh -a $ARCH -o $LXDE_IMG -p "$LXDE_PKGS" ${REPO} "$@"
-	fi
-fi
-if [ -z "$IMAGE" -o "$IMAGE" = lxqt ]; then
-	if [ ! -e $LXQT_IMG ]; then
-		./mklive.sh -a $ARCH -o $LXQT_IMG -p "$LXQT_PKGS" ${REPO} "$@"
-	fi
-fi
-if [ "$IMAGE" = kde ]; then
-	if [ ! -e $KDE_IMG ]; then
-		./mklive.sh -a $ARCH -o $KDE_IMG -p "$KDE_PKGS" ${REPO} "$@"
-	fi
-fi
+for image in $IMAGES; do
+    build_variant "$image"
+done


### PR DESCRIPTION
* rename e to enlightenment
* enable building kde by default
* allow building multiple, but not all images (ex. -b "base xfce")
* run the script with set -e (exit when there is an error)