### PR TITLE
build-x86-images: use -base suffix for the base iso

### DIFF
--- a/build-x86-images.sh.in
+++ b/build-x86-images.sh.in
@@ -24,11 +24,7 @@ shift $((OPTIND - 1))
 
 build_variant() {
     variant="$1"
-    IMG_SUFFIX="-$variant"
-    if [ "$variant" = base ]; then
-        IMG_SUFFIX=
-    fi
-    IMG=void-live-${ARCH}-${DATE}${IMG_SUFFIX}.iso
+    IMG=void-live-${ARCH}-${DATE}-${variant}.iso
     GRUB_PKGS="grub-i386-efi grub-x86_64-efi"
     PKGS="dialog cryptsetup lvm2 mdadm void-docs-browse $GRUB_PKGS"
     XORG_PKGS="xorg-minimal xorg-input-drivers xorg-video-drivers setxkbmap xauth font-misc-misc terminus-font dejavu-fonts-ttf alsa-plugins-pulseaudio"


### PR DESCRIPTION
All other variants have their variant name in the iso file name and the base flavor is not really special. This means the iso will change its name, but the date changes with every release anyway, so it shouldn't be a big issue. 