### PR TITLE
build-x86-images: fix error with missing mklive.sh

### DIFF
--- a/build-x86-images.sh.in
+++ b/build-x86-images.sh.in
@@ -68,7 +68,10 @@ build_variant() {
     ./mklive.sh -a "$ARCH" -o "$IMG" -p "$PKGS" ${REPO} "$@"
 }
 
-[ ! -x mklive.sh ] && exit 0
+if [ ! -x mklive.sh ]; then
+    echo mklive.sh not found >&2
+    exit 1
+fi
 
 for image in $IMAGES; do
     build_variant "$image"


### PR DESCRIPTION
* print an error message to stderr
* exit with return code 1