### PR TITLE
installer: use `defaults` mount option for swap

### DIFF
--- a/installer.sh.in
+++ b/installer.sh.in
@@ -1039,7 +1039,7 @@ failed to activate swap on $dev!\ncheck $LOG for errors." ${MSGBOXSIZE}
             fi
             # Add entry for target fstab
             uuid=$(blkid -o value -s UUID "$dev")
-            echo "UUID=$uuid none swap sw 0 0" >>$TARGET_FSTAB
+            echo "UUID=$uuid none swap defaults 0 0" >>$TARGET_FSTAB
             continue
         fi
 


### PR DESCRIPTION
this changes nothing in practice, but `sw` has no actual meaning on
Linux

<https://github.com/void-linux/void-docs/pull/693#issuecomment-1203753228>