### PR TITLE
various: switch from rpi{,2,3,4} to rpi-$ARCH for rpi images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ SCRIPTS += $(SHIN:.sh.in=.sh)
 DATECODE=$(shell date "+%Y%m%d")
 SHELL=/bin/bash
 
-T_PLATFORMS=rpi{,2,3,4}{,-musl} beaglebone{,-musl} cubieboard2{,-musl} odroid-c2{,-musl} GCP{,-musl} pinebookpro{,-musl}
+T_PLATFORMS=rpi-{armv{6,7}l,aarch64}{,-musl} beaglebone{,-musl} cubieboard2{,-musl} odroid-c2{,-musl} GCP{,-musl} pinebookpro{,-musl}
 T_ARCHS=i686 x86_64{,-musl} armv{6,7}l{,-musl} aarch64{,-musl}
 
-T_SBC_IMGS=rpi{,2,3,4}{,-musl} beaglebone{,-musl} cubieboard2{,-musl} odroid-c2{,-musl} pinebookpro{,-musl}
+T_SBC_IMGS=rpi-{armv{6,7}l,aarch64}{,-musl} beaglebone{,-musl} cubieboard2{,-musl} odroid-c2{,-musl} pinebookpro{,-musl}
 T_CLOUD_IMGS=GCP{,-musl}
 
 T_PXE_ARCHS=x86_64{,-musl}

--- a/lib.sh.in
+++ b/lib.sh.in
@@ -287,10 +287,9 @@ set_target_arch_from_platform() {
         cubieboard2*|cubietruck*) XBPS_TARGET_ARCH="armv7l";;
         odroid-u2*) XBPS_TARGET_ARCH="armv7l";;
         odroid-c2*) XBPS_TARGET_ARCH="aarch64";;
-        rpi4*) XBPS_TARGET_ARCH="aarch64";;
-        rpi3*) XBPS_TARGET_ARCH="aarch64";;
-        rpi2*) XBPS_TARGET_ARCH="armv7l";;
-        rpi*) XBPS_TARGET_ARCH="armv6l";;
+        rpi-aarch64*) XBPS_TARGET_ARCH="aarch64";;
+        rpi-armv7l*) XBPS_TARGET_ARCH="armv7l";;
+        rpi-armv6l*) XBPS_TARGET_ARCH="armv6l";;
         ci20*) XBPS_TARGET_ARCH="mipsel";;
         i686*) XBPS_TARGET_ARCH="i686";;
         x86_64*) XBPS_TARGET_ARCH="x86_64";;

--- a/mkimage.sh.in
+++ b/mkimage.sh.in
@@ -117,7 +117,7 @@ PLATFORM="${PLATFORM%-PLATFORMFS*}"
 
 # Be absolutely certain the platform is supported before continuing
 case "$PLATFORM" in
-    bananapi|beaglebone|cubieboard2|cubietruck|odroid-c2|odroid-u2|rpi|rpi2|rpi3|rpi4|GCP|pinebookpro|pinephone|rock64|*-musl);;
+    bananapi|beaglebone|cubieboard2|cubietruck|odroid-c2|odroid-u2|rpi-armv6l|rpi-armv7l|rpi-aarch64|GCP|pinebookpro|pinephone|rock64|*-musl);;
     *) die "The $PLATFORM is not supported, exiting..."
 esac
 

--- a/mkplatformfs.sh.in
+++ b/mkplatformfs.sh.in
@@ -50,7 +50,7 @@ Usage: $PROGNAME [options] <platform> <base-tarball>
 
 Supported platforms: i686, x86_64, GCP, bananapi, beaglebone,
                      cubieboard2, cubietruck, odroid-c2, odroid-u2,
-                     rpi, rpi2 (armv7), rpi3 (aarch64), rpi4 (aarch64), ci20,
+                     rpi-armv6l, rpi-armv7l, rpi-aarch64, ci20,
                      pinebookpro, pinephone, rock64
 
 Options
@@ -117,9 +117,6 @@ case "$PLATFORM" in
     cubieboard2*|cubietruck*) PKGS="$BASEPKG ${PLATFORM%-*}-base" ;;
     odroid-u2*) PKGS="$BASEPKG ${PLATFORM%-*}-base" ;;
     odroid-c2*) PKGS="$BASEPKG ${PLATFORM%-musl}-base" ;;
-    rpi4*) PKGS="$BASEPKG rpi4-base" ;;
-    rpi3*) PKGS="$BASEPKG rpi3-base" ;;
-    rpi2*) PKGS="$BASEPKG rpi2-base" ;;
     rpi*) PKGS="$BASEPKG rpi-base" ;;
     ci20*) PKGS="$BASEPKG ${PLATFORM%-*}-base" ;;
     i686*) PKGS="$BASEPKG" ;;

--- a/release.sh.in
+++ b/release.sh.in
@@ -6,8 +6,8 @@ DATECODE=$(date "+%Y%m%d")
 make
 
 ARCHS="$(echo x86_64{,-musl} i686 armv{6,7}l{,-musl} aarch64{,-musl})"
-PLATFORMS="$(echo rpi{,2,3,4}{,-musl})"
-SBC_IMGS="$(echo rpi{,2,3,4}{,-musl})"
+PLATFORMS="$(echo rpi-{armv{6,7}l,aarch64}{,-musl})"
+SBC_IMGS="$(echo rpi-{armv{6,7}l,aarch64}{,-musl})"
 
 make rootfs-all ARCHS="$ARCHS" XBPS_REPOSITORY="$XBPS_REPOSITORY" DATECODE="$DATECODE"
 make platformfs-all PLATFORMS="$PLATFORMS" XBPS_REPOSITORY="$XBPS_REPOSITORY" DATECODE="$DATECODE"


### PR DESCRIPTION
with the merge of rpi kernels, we no longer need to generate board-series-specific images

for void-linux/void-packages#39442

```
$ ls -1 void-rpi*
void-rpi-aarch64-20221001.img
void-rpi-aarch64-20221001.img.xz
void-rpi-aarch64-PLATFORMFS-20221001.tar.xz
void-rpi-aarch64-musl-20221001.img
void-rpi-aarch64-musl-20221001.img.xz
void-rpi-aarch64-musl-PLATFORMFS-20221001.tar.xz
void-rpi-armv6l-20221001.img
void-rpi-armv6l-20221001.img.xz
void-rpi-armv6l-PLATFORMFS-20221001.tar.xz
void-rpi-armv6l-musl-20221001.img
void-rpi-armv6l-musl-20221001.img.xz
void-rpi-armv6l-musl-PLATFORMFS-20221001.tar.xz
void-rpi-armv7l-20221001.img
void-rpi-armv7l-20221001.img.xz
void-rpi-armv7l-PLATFORMFS-20221001.tar.xz
void-rpi-armv7l-musl-20221001.img
void-rpi-armv7l-musl-20221001.img.xz
void-rpi-armv7l-musl-PLATFORMFS-20221001.tar.xz
```