### PR TITLE
build-x86-images: include console screenreader

### DIFF
--- a/build-x86-images.sh.in
+++ b/build-x86-images.sh.in
@@ -28,6 +28,7 @@ build_variant() {
     IMG=void-live-${ARCH}-${DATE}-${variant}.iso
     GRUB_PKGS="grub-i386-efi grub-x86_64-efi"
     PKGS="dialog cryptsetup lvm2 mdadm void-docs-browse xtools-minimal xmirror $GRUB_PKGS"
+    PKGS="dialog cryptsetup lvm2 mdadm void-docs-browse xtools-minimal xmirror espeakup $GRUB_PKGS"
     XORG_PKGS="xorg-minimal xorg-input-drivers xorg-video-drivers setxkbmap xauth font-misc-misc terminus-font dejavu-fonts-ttf alsa-plugins-pulseaudio"
     SERVICES="sshd"
 

--- a/dracut/vmklive/module-setup.sh
+++ b/dracut/vmklive/module-setup.sh
@@ -27,4 +27,5 @@ install() {
     inst_hook pre-pivot 02 "$moddir/display-manager-autologin.sh"
     inst_hook pre-pivot 02 "$moddir/getty-serial.sh"
     inst_hook pre-pivot 03 "$moddir/locale.sh"
+    inst_hook pre-pivot 04 "$moddir/screenreader.sh"
 }

--- a/dracut/vmklive/screenreader.sh
+++ b/dracut/vmklive/screenreader.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -x
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+type getargbool >/dev/null 2>&1 || . /lib/dracut-lib.sh
+
+if getargbool 0 live.screenreader && [ -d "${NEWROOT}/etc/sv/espeakup" ]; then
+	ln -s /etc/sv/espeakup "${NEWROOT}/etc/runit/runsvdir/current/"
+fi

--- a/installer.sh.in
+++ b/installer.sh.in
@@ -1324,7 +1324,12 @@ ${BOLD}Do you want to continue?${RESET}" 20 80 || return
         chroot $TARGETDIR dracut --no-hostonly --add-drivers "ahci" --force >>$LOG 2>&1
         INFOBOX "Removing temporary packages from target ..." 4 60
         echo "Removing temporary packages from target ..." >$LOG
-        xbps-remove -r $TARGETDIR -Ry dialog xtools-minimal xmirror >>$LOG 2>&1
+        TO_REMOVE="dialog xtools-minimal"
+        # only remove espeakup if it wasn't enabled in the live environment
+        if ! [ -e "/var/service/espeakup" ]; then
+            TO_REMOVE+=" espeakup"
+        fi
+        xbps-remove -r $TARGETDIR -Ry $TO_REMOVE >>$LOG 2>&1
         rmdir $TARGETDIR/mnt/target
     else
         # mount required fs


### PR DESCRIPTION
- espeakup is a screenreader for console environments
- orca is a screenreader for gui environments

they are a minimal increase to the size of the live images, but I think they are an important accessibility feature to add.

neither is enabled by default, but they are easily enabled via `ln -s /etc/sv/espeakup /var/service` or running `orca -r` (this should also be documented in void-docs eventually).

**Should these also be included in the rpi images and the various ROOTFS/PLATFORMFSes too?**

## Testing

live images for testing are here: https://devspace.voidlinux.org/abby/live-a11y/

- [x] espeakup
  - tested on an x86_64-base image
  - it might be nice to have a more convenient way to enable the service (like a `enable-espeakup` script, maybe), to minimise the chance for errors in typing the `ln` command without a screenreader (for users who need it)
- [ ] orca
  - tried to get it working on an x86_64-xfce image, but couldn't get it to speak

