### PR TITLE
mklive.sh: move installer.sh to build-x86-images.sh 

### DIFF
--- a/build-x86-images.sh.in
+++ b/build-x86-images.sh.in
@@ -22,6 +22,13 @@ esac
 done
 shift $((OPTIND - 1))
 
+INCLUDEDIR=$(mktemp -d)
+trap "cleanup" INT TERM
+
+cleanup() {
+    rm -r "$INCLUDEDIR"
+}
+
 build_variant() {
     variant="$1"
     shift
@@ -74,11 +81,18 @@ build_variant() {
         ;;
     esac
 
-    ./mklive.sh -a "$ARCH" -o "$IMG" -p "$PKGS" -S "$SERVICES" ${REPO} "$@"
+    ./mklive.sh -a "$ARCH" -o "$IMG" -p "$PKGS" -S "$SERVICES" -I "$INCLUDEDIR" ${REPO} "$@"
 }
 
 if [ ! -x mklive.sh ]; then
     echo mklive.sh not found >&2
+    exit 1
+fi
+
+if [ -x installer.sh ]; then
+    install -Dm755 installer.sh "$INCLUDEDIR"/usr/bin/void-installer
+else
+    echo installer.sh not found >&2
     exit 1
 fi
 

--- a/mklive.sh.in
+++ b/mklive.sh.in
@@ -133,7 +133,6 @@ install_packages() {
     fi
     chroot "$ROOTFS" env -i xbps-reconfigure -a
 
-    install -Dm755 installer.sh "$ROOTFS"/usr/sbin/void-installer
     # Cleanup and remove useless stuff.
     rm -rf "$ROOTFS"/var/cache/* "$ROOTFS"/run/* "$ROOTFS"/var/run/*
 }

--- a/mklive.sh.in
+++ b/mklive.sh.in
@@ -133,11 +133,7 @@ install_packages() {
     fi
     chroot "$ROOTFS" env -i xbps-reconfigure -a
 
-    if [ -x installer.sh ]; then
-        install -Dm755 installer.sh "$ROOTFS"/usr/sbin/void-installer
-    else
-        install -Dm755 /usr/sbin/void-installer "$ROOTFS"/usr/sbin/void-installer
-    fi
+    install -Dm755 installer.sh "$ROOTFS"/usr/sbin/void-installer
     # Cleanup and remove useless stuff.
     rm -rf "$ROOTFS"/var/cache/* "$ROOTFS"/run/* "$ROOTFS"/var/run/*
 }


### PR DESCRIPTION
Running `mklive.sh` without any arguments produces a minimal image that doesn't have dialog installed which is required for installer.sh. Let's move installing the installer script up a level to `build-x86-64-images.sh` which already adds a dialog dependency.