### PR TITLE
build-x86-images: fix mklive argument passtrough

### DIFF
--- a/build-x86-images.sh.in
+++ b/build-x86-images.sh.in
@@ -24,6 +24,7 @@ shift $((OPTIND - 1))
 
 build_variant() {
     variant="$1"
+    shift
     IMG=void-live-${ARCH}-${DATE}-${variant}.iso
     GRUB_PKGS="grub-i386-efi grub-x86_64-efi"
     PKGS="dialog cryptsetup lvm2 mdadm void-docs-browse xtools-minimal $GRUB_PKGS"
@@ -81,5 +82,5 @@ if [ ! -x mklive.sh ]; then
 fi
 
 for image in $IMAGES; do
-    build_variant "$image"
+    build_variant "$image" "$@"
 done

--- a/mklive.sh.in
+++ b/mklive.sh.in
@@ -304,10 +304,10 @@ while getopts "a:b:r:c:C:T:Kk:l:i:I:S:s:o:p:v:h" opt; do
         l) LOCALE="$OPTARG";;
         i) INITRAMFS_COMPRESSION="$OPTARG";;
         I) INCLUDE_DIRECTORY="$OPTARG";;
-        S) SERVICE_LIST="$OPTARG";;
+        S) SERVICE_LIST="$SERVICE_LIST $OPTARG";;
         s) SQUASHFS_COMPRESSION="$OPTARG";;
         o) OUTPUT_FILE="$OPTARG";;
-        p) PACKAGE_LIST="$OPTARG";;
+        p) PACKAGE_LIST="$PACKAGE_LIST $OPTARG";;
         C) BOOT_CMDLINE="$OPTARG";;
         T) BOOT_TITLE="$OPTARG";;
         v) LINUX_VERSION="$OPTARG";;
@@ -437,5 +437,3 @@ generate_iso_image
 
 hsize=$(du -sh "$OUTPUT_FILE"|awk '{print $1}')
 info_msg "Created $(readlink -f "$OUTPUT_FILE") ($hsize) successfully."
-
-


### PR DESCRIPTION
- **build-x86-images: Fix passing of additional arguments to mklive**
    Mklive is called with `"$@"` to be able to pass additional arguments to it. However, since mklive is called from within a function, the value of `"$@"` is the function's argument.
This is fixed by adding `"$@"` to the function call and using shift after its first argument (the image flavour) is used.

- **mklive: Accept multiple instances of -p and -S**
    This allows passing a list of packages and services to `build-x86-images.sh` without overriding its own list of packages and services passed to mklive.