### PR TITLE
user creation omnibus

### DIFF
--- a/installer.sh.in
+++ b/installer.sh.in
@@ -1454,6 +1454,7 @@ menu() {
         # Show settings
         cp $CONF_FILE /tmp/conf_hidden.$$;
         sed -i "s/^ROOTPASSWORD.*/ROOTPASSWORD <-hidden->/" /tmp/conf_hidden.$$
+        sed -i "s/^USERPASSWORD.*/USERPASSWORD <-hidden->/" /tmp/conf_hidden.$$
         DIALOG --title "Saved settings for installation" --textbox /tmp/conf_hidden.$$ 14 60
         rm /tmp/conf_hidden.$$
         return

--- a/installer.sh.in
+++ b/installer.sh.in
@@ -660,7 +660,7 @@ menu_rootpassword() {
 }
 
 set_rootpassword() {
-    echo "root:$(get_option ROOTPASSWORD)" | chpasswd -R $TARGETDIR -c SHA512
+    echo "root:$(get_option ROOTPASSWORD)" | chroot $TARGETDIR chpasswd -c SHA512
 }
 
 menu_useraccount() {
@@ -769,10 +769,10 @@ set_useraccount() {
     [ -z "$USERPASSWORD_DONE" ] && return
     [ -z "$USERNAME_DONE" ] && return
     [ -z "$USERGROUPS_DONE" ] && return
-    useradd -R "$TARGETDIR" -m -G "$(get_option USERGROUPS)" \
+    chroot $TARGETDIR useradd -m -G "$(get_option USERGROUPS)" \
         -c "$(get_option USERNAME)" "$(get_option USERLOGIN)"
     echo "$(get_option USERLOGIN):$(get_option USERPASSWORD)" | \
-        chpasswd -R $TARGETDIR -c SHA512
+        chroot $TARGETDIR chpasswd -c SHA512
 }
 
 menu_bootloader() {

--- a/installer.sh.in
+++ b/installer.sh.in
@@ -624,7 +624,8 @@ menu_hostname() {
 }
 
 set_hostname() {
-    echo $(get_option HOSTNAME) > $TARGETDIR/etc/hostname
+    local hostname="$(get_option HOSTNAME)"
+    echo "${hostname:-void}" > $TARGETDIR/etc/hostname
 }
 
 menu_rootpassword() {


### PR DESCRIPTION
- installer: use chroot instead of -R arg for useradd/chpasswd
    - fixes #18
    - fixes #181
    - fixes #306
- installer: hide USERPASSWORD in settings
    - fixes #240
- installer: default hostname to 'void' if unset
    - just something i noticed along the way

