### PR TITLE
build-x86-images.sh: use lightdm instead of lxdm

### DIFF
--- a/build-x86-images.sh.in
+++ b/build-x86-images.sh.in
@@ -36,20 +36,20 @@ build_variant() {
             SERVICES="$SERVICES dhcpcd wpa_supplicant acpid"
         ;;
         enlightenment)
-            PKGS="$PKGS $XORG_PKGS lxdm enlightenment terminology udisks2 firefox"
-            SERVICES="$SERVICES acpid dhcpcd wpa_supplicant lxdm dbus polkitd"
+            PKGS="$PKGS $XORG_PKGS lightdm lightdm-gtk3-greeter enlightenment terminology udisks2 firefox"
+            SERVICES="$SERVICES acpid dhcpcd wpa_supplicant lightdm dbus polkitd"
         ;;
         xfce)
-            PKGS="$PKGS $XORG_PKGS lxdm xfce4 gnome-themes-standard gnome-keyring network-manager-applet gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox"
-            SERVICES="$SERVICES dbus elogind lxdm NetworkManager polkitd"
+            PKGS="$PKGS $XORG_PKGS lightdm lightdm-gtk3-greeter xfce4 gnome-themes-standard gnome-keyring network-manager-applet gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox"
+            SERVICES="$SERVICES dbus elogind lightdm NetworkManager polkitd"
         ;;
         mate)
-            PKGS="$PKGS $XORG_PKGS lxdm mate mate-extra gnome-keyring network-manager-applet gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox"
-            SERVICES="$SERVICES dbus elogind lxdm NetworkManager polkitd"
+            PKGS="$PKGS $XORG_PKGS lightdm lightdm-gtk3-greeter mate mate-extra gnome-keyring network-manager-applet gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox"
+            SERVICES="$SERVICES dbus elogind lightdm NetworkManager polkitd"
         ;;
         cinnamon)
-            PKGS="$PKGS $XORG_PKGS lxdm cinnamon gnome-keyring colord gnome-terminal gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox"
-            SERVICES="$SERVICES dbus elogind lxdm NetworkManager polkitd"
+            PKGS="$PKGS $XORG_PKGS lightdm lightdm-gtk3-greeter cinnamon gnome-keyring colord gnome-terminal gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox"
+            SERVICES="$SERVICES dbus elogind lightdm NetworkManager polkitd"
         ;;
         gnome)
             PKGS="$PKGS $XORG_PKGS gnome firefox"
@@ -60,12 +60,12 @@ build_variant() {
             SERVICES="$SERVICES dbus elogind NetworkManager sddm"
         ;;
         lxde)
-            PKGS="$PKGS $XORG_PKGS lxde lxdm gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox"
-            SERVICES="$SERVICES acpid dbus dhcpcd wpa_supplicant lxdm polkitd"
+            PKGS="$PKGS $XORG_PKGS lxde lightdm lightdm-gtk3-greeter gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox"
+            SERVICES="$SERVICES acpid dbus dhcpcd wpa_supplicant lightdm polkitd"
         ;;
         lxqt)
-            PKGS="$PKGS $XORG_PKGS lxqt lxdm gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox"
-            SERVICES="$SERVICES elogind dbus dhcpcd wpa_supplicant lxdm polkitd"
+            PKGS="$PKGS $XORG_PKGS lxqt sddm gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox"
+            SERVICES="$SERVICES elogind dbus dhcpcd wpa_supplicant sddm polkitd"
         ;;
         *)
             >&2 echo "Unknown variant $variant"


### PR DESCRIPTION
Lxdm is an old project with, the last release is from 2015 and users sometimes report lxdm giving them a black unresponsive screen after an update.

LightDM is much more maintained and much more common nowadays.

Closes: #271
Closes: #79