### PR TITLE
mklive.sh: check arch validity after the default is set

### DIFF
--- a/mklive.sh.in
+++ b/mklive.sh.in
@@ -318,11 +318,6 @@ done
 shift $((OPTIND - 1))
 XBPS_REPOSITORY="$XBPS_REPOSITORY --repository=https://repo-default.voidlinux.org/current --repository=https://repo-default.voidlinux.org/current/musl"
 
-case $BASE_ARCH in
-    x86_64*|i686*) ;;
-    *) >&2 echo architecture $BASE_ARCH not supported by mklive.sh; exit 1;;
-esac
-
 # Configure dracut to use overlayfs for the writable overlay.
 BOOT_CMDLINE="$BOOT_CMDLINE rd.live.overlay.overlayfs=1 "
 
@@ -338,6 +333,11 @@ ARCH=$(xbps-uhelper arch)
 : ${SQUASHFS_COMPRESSION:=xz}
 : ${BASE_SYSTEM_PKG:=base-system}
 : ${BOOT_TITLE:="Void Linux"}
+
+case $BASE_ARCH in
+    x86_64*|i686*) ;;
+    *) >&2 echo architecture $BASE_ARCH not supported by mklive.sh; exit 1;;
+esac
 
 # Required packages in the image for a working system.
 PACKAGE_LIST="$BASE_SYSTEM_PKG $PACKAGE_LIST"


### PR DESCRIPTION
It's possible to run mklive.sh without the -a argument in which case, the architecture is supposed to be set to the current one using xbps-uhelper. This means we have to check whether the architecture is valid after this default has been set, otherwise we get an empty string which is not a valid architecture.