### PR TITLE
installer.sh.in: sort filesystems by mountpoint

### DIFF
--- a/installer.sh.in
+++ b/installer.sh.in
@@ -1039,7 +1039,7 @@ as FAT32, mountpoint /boot/efi and at least with 100MB of size." ${MSGBOXSIZE}
 create_filesystems() {
     local mnts dev mntpt fstype fspassno mkfs size rv uuid
 
-    mnts=$(grep -E '^MOUNTPOINT.*' $CONF_FILE)
+    mnts=$(grep -E '^MOUNTPOINT.*' $CONF_FILE | sort -k 5)
     set -- ${mnts}
     while [ $# -ne 0 ]; do
         dev=$2; fstype=$3; mntpt="$5"; mkfs=$6
@@ -1109,7 +1109,7 @@ failed to mount $dev on ${mntpt}! check $LOG for errors." ${MSGBOXSIZE}
     done
 
     # mount all filesystems in target rootfs
-    mnts=$(grep -E '^MOUNTPOINT.*' $CONF_FILE)
+    mnts=$(grep -E '^MOUNTPOINT.*' $CONF_FILE | sort -k 5)
     set -- ${mnts}
     while [ $# -ne 0 ]; do
         dev=$2; fstype=$3; mntpt="$5"
@@ -1149,7 +1149,7 @@ umount_filesystems() {
         echo "Unmounting $TARGETDIR/$f..." >$LOG
         umount $TARGETDIR/$f >$LOG 2>&1
     done
-    local mnts="$(grep -E '^MOUNTPOINT.*$' $CONF_FILE)"
+    local mnts="$(grep -E '^MOUNTPOINT.*$' $CONF_FILE | sort -r -k 5)"
     set -- ${mnts}
     while [ $# -ne 0 ]; do
         local dev=$2; local fstype=$3; local mntpt=$5


### PR DESCRIPTION
fixes #131
fixes #323

This partition layout fails to install grub on the last release, but succeeds with the sorting added in this PR:
![image](https://user-images.githubusercontent.com/5366828/230696073-37566aff-726c-4e0f-a7ea-3524286a7e9c.png)
