### PR TITLE
installer: check for network on source selection

### DIFF
--- a/installer.sh.in
+++ b/installer.sh.in
@@ -1394,7 +1394,9 @@ menu_source() {
         "Local") src="local";;
         "Network") src="net";
             if [ -z "$NETWORK_DONE" ]; then
-                menu_network;
+                if test_network; then
+                    menu_network
+                fi
             fi;;
         *) return 1;;
     esac


### PR DESCRIPTION
this well prevent needing to go through the network menu if it was already set up externally, and the user skips it before setting the source to network.

fixes #171
