### PR TITLE
CI for building images

### DIFF
--- a/.github/workflows/gen-images.yml
+++ b/.github/workflows/gen-images.yml
@@ -1,0 +1,130 @@
+name: Build void images
+
+on:
+  workflow_dispatch:
+    inputs:
+      datecode:
+        description: "Override datecode for images"
+        required: false
+        type: string
+      mirror:
+        description: "Mirror to use"
+        default: "https://repo-ci.voidlinux.org/current"
+        required: false
+        type: string
+      live_archs:
+        description: "Archs to build live ISOs for"
+        default: "x86_64 x86_64-musl i686"
+        required: false
+        type: string
+      live_flavors:
+        description: "Flavors to build live ISOs for"
+        default: "base xfce"
+        required: false
+        type: string
+      rootfs:
+        description: "Archs to build ROOTFSes for"
+        default: "x86_64 x86_64-musl i686 armv6l armv6l-musl armv7l armv7l-musl aarch64 aarch64-musl"
+        required: false
+        type: string
+      platformfs:
+        description: "Platforms to build PLATFORMFSes for"
+        default: "rpi-armv6l rpi-armv6l-musl rpi-armv7l rpi-armv7l-musl rpi-aarch64 rpi-aarch64-musl"
+        required: false
+        type: string
+      sbc_imgs:
+        description: "Platforms to build SBC images for"
+        default: "rpi-armv6l rpi-armv6l-musl rpi-armv7l rpi-armv7l-musl rpi-aarch64 rpi-aarch64-musl"
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    container:
+      image: 'ghcr.io/void-linux/void-linux:20230204RC01-full-x86_64'
+      options: --privileged
+      volumes:
+        - /dev:/dev
+      env:
+        PATH: '/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/sbin:/usr/local/bin:/tmp/bin'
+        DATECODE: "${{ inputs.datecode }}"
+        LIVE_ARCHS: "${{ inputs.live_archs }}"
+        LIVE_FLAVORS: "${{ inputs.live_flavors }}"
+        ROOTFS_ARCHS: "${{ inputs.rootfs }}"
+        PLATFORMS: "${{ inputs.platformfs }}"
+        SBC_IMGS: "${{ inputs.sbc_imgs }}"
+        REPO: "${{ inputs.mirror }}"
+
+    steps:
+      - name: Prepare container
+        shell: sh
+        run: |
+          # Switch to repo-ci mirror
+          mkdir -p /etc/xbps.d && cp /usr/share/xbps.d/*-repository-*.conf /etc/xbps.d/
+          sed -i 's|https://repo-default.voidlinux.org/current|'"$REPO"'|g' /etc/xbps.d/*-repository-*.conf
+          # Sync and upgrade once, assume error comes from xbps update
+          xbps-install -Syu || xbps-install -yu xbps
+          # Upgrade again (in case there was a xbps update)
+          xbps-install -yu
+          # Install depedencies
+          xbps-install -yu bash make git kmod xz lzo qemu-user-static outils dosfstools e2fsprogs
+
+      - name: Clone and checkout
+        uses: classabbyamp/treeless-checkout-action@v1
+      - name: Prepare environment
+        run: |
+          echo "DATECODE=$(date -u "+%Y%m%d")" >> $GITHUB_ENV
+          echo "MKLIVE_REV=${GITHUB_SHA:0:8}" >> $GITHUB_ENV
+      - name: Build live ISOs
+        run: |
+          if ! [[ "$LIVE_ARCHS" = "none" || "$LIVE_FLAVORS" = "none" ]]; then
+              make live-iso-all{-print,} \
+                  LIVE_ARCHS="$LIVE_ARCHS" LIVE_FLAVORS="$LIVE_FLAVORS" \
+                  SUDO= REPOSITORY="$REPO" DATECODE=$DATECODE
+          else
+              echo "Nothing to do..."
+          fi
+      - name: Build ROOTFSes
+        run: |
+          if ! [ "$ROOTFS_ARCHS" = "none" ]; then
+              make rootfs-all{-print,} \
+                  SUDO= ARCHS="$ROOTFS_ARCHS" REPOSITORY="$REPO" DATECODE=$DATECODE
+          else
+              echo "Nothing to do..."
+          fi
+      - name: Build PLATFORMFSes
+        run: |
+          if ! [ "$PLATFORMS" = "none" ]; then
+              make platformfs-all{-print,} \
+                  SUDO= PLATFORMS="$PLATFORMS" REPOSITORY="$REPO" DATECODE=$DATECODE
+          else
+              echo "Nothing to do..."
+          fi
+      - name: Build SBC images
+        run: |
+          if ! [ "$SBC_IMGS" = "none" ]; then
+              make images-all-sbc{-print,} \
+                  SUDO= SBC_IMGS="$SBC_IMGS" REPOSITORY="$REPO" DATECODE=$DATECODE
+          else
+              echo "Nothing to do..."
+          fi
+      - name: Prepare artifacts for upload
+        run: |
+          make dist checksum DATECODE=$DATECODE
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: void-live-${{ env.DATECODE }}
+          path: distdir-${{ env.DATECODE }}/*
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ xbps-cachedir*
 stamps*
 !dracut/*/*.sh
 !packer/scripts/*.sh
+void-live-*/
+release/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-SCRIPTS += $(shell find -type f -name '*.sh')
-DATECODE=$(shell date "+%Y%m%d")
+DATECODE:=$(shell date -u "+%Y%m%d")
 SHELL=/bin/bash
+
+T_LIVE_ARCHS=i686 x86_64{,-musl}
 
 T_PLATFORMS=rpi-{armv{6,7}l,aarch64}{,-musl} beaglebone{,-musl} cubieboard2{,-musl} odroid-c2{,-musl} GCP{,-musl} pinebookpro{,-musl}
 T_ARCHS=i686 x86_64{,-musl} armv{6,7}l{,-musl} aarch64{,-musl}
@@ -10,12 +11,15 @@ T_CLOUD_IMGS=GCP{,-musl}
 
 T_PXE_ARCHS=x86_64{,-musl}
 
-ARCHS=$(shell echo $(T_ARCHS))
-PLATFORMS=$(shell echo $(T_PLATFORMS))
-SBC_IMGS=$(shell echo $(T_SBC_IMGS))
-CLOUD_IMGS=$(shell echo $(T_CLOUD_IMGS))
-PXE_ARCHS=$(shell echo $(T_PXE_ARCHS))
+LIVE_ARCHS:=$(shell echo $(T_LIVE_ARCHS))
+LIVE_FLAVORS:=base enlightenment xfce mate cinnamon gnome kde lxde lxqt
+ARCHS:=$(shell echo $(T_ARCHS))
+PLATFORMS:=$(shell echo $(T_PLATFORMS))
+SBC_IMGS:=$(shell echo $(T_SBC_IMGS))
+CLOUD_IMGS:=$(shell echo $(T_CLOUD_IMGS))
+PXE_ARCHS:=$(shell echo $(T_PXE_ARCHS))
 
+ALL_LIVE_ISO=$(foreach arch,$(LIVE_ARCHS), $(foreach flavor,$(LIVE_FLAVORS),void-live-$(arch)-$(DATECODE)-$(flavor).iso))
 ALL_ROOTFS=$(foreach arch,$(ARCHS),void-$(arch)-ROOTFS-$(DATECODE).tar.xz)
 ALL_PLATFORMFS=$(foreach platform,$(PLATFORMS),void-$(platform)-PLATFORMFS-$(DATECODE).tar.xz)
 ALL_SBC_IMAGES=$(foreach platform,$(SBC_IMGS),void-$(platform)-$(DATECODE).img.xz)
@@ -24,10 +28,14 @@ ALL_PXE_ARCHS=$(foreach arch,$(PXE_ARCHS),void-$(arch)-NETBOOT-$(DATECODE).tar.g
 
 SUDO := sudo
 
-XBPS_REPOSITORY := -r https://repo-default.voidlinux.org/current -r https://repo-default.voidlinux.org/current/musl -r https://repo-default.voidlinux.org/current/aarch64
-COMPRESSOR_THREADS=2
+REPOSITORY := https://repo-default.voidlinux.org/current
+XBPS_REPOSITORY := -r $(REPOSITORY) -r $(REPOSITORY)/musl -r $(REPOSITORY)/aarch64
+COMPRESSOR_THREADS:=2
 
 all:
+
+checksum: dist
+	cd distdir-$(DATECODE)/ && sha256 * > sha256sum.txt
 
 distdir-$(DATECODE):
 	mkdir -p distdir-$(DATECODE)
@@ -35,21 +43,36 @@ distdir-$(DATECODE):
 dist: distdir-$(DATECODE)
 	mv void*$(DATECODE)* distdir-$(DATECODE)/
 
+live-iso-all: $(ALL_LIVE_ISO)
+
+live-iso-all-print:
+	@echo $(ALL_LIVE_ISO) | sed "s: :\n:g"
+
+void-live-%.iso:
+	@[ -n "${CI}" ] && printf "::group::\x1b[32mBuilding $@...\x1b[0m\n" || true
+	$(SUDO) ./build-x86-images.sh -r $(REPOSITORY) -t $*
+	@[ -n "${CI}" ] && printf '::endgroup::\n' || true
+
 rootfs-all: $(ALL_ROOTFS)
 
 rootfs-all-print:
 	@echo $(ALL_ROOTFS) | sed "s: :\n:g"
 
-void-%-ROOTFS-$(DATECODE).tar.xz: $(SCRIPTS)
+void-%-ROOTFS-$(DATECODE).tar.xz:
+	@[ -n "${CI}" ] && printf "::group::\x1b[32mBuilding $@...\x1b[0m\n" || true
 	$(SUDO) ./mkrootfs.sh $(XBPS_REPOSITORY) -x $(COMPRESSOR_THREADS) $*
+	@[ -n "${CI}" ] && printf '::endgroup::\n' || true
 
 platformfs-all: $(ALL_PLATFORMFS)
 
 platformfs-all-print:
 	@echo $(ALL_PLATFORMFS) | sed "s: :\n:g"
 
-void-%-PLATFORMFS-$(DATECODE).tar.xz: $(SCRIPTS)
+.SECONDEXPANSION:
+void-%-PLATFORMFS-$(DATECODE).tar.xz: void-$$(shell ./lib.sh platform2arch %)-ROOTFS-$(DATECODE).tar.xz
+	@[ -n "${CI}" ] && printf "::group::\x1b[32mBuilding $@...\x1b[0m\n" || true
 	$(SUDO) ./mkplatformfs.sh $(XBPS_REPOSITORY) -x $(COMPRESSOR_THREADS) $* void-$(shell ./lib.sh platform2arch $*)-ROOTFS-$(DATECODE).tar.xz
+	@[ -n "${CI}" ] && printf '::endgroup::\n' || true
 
 images-all: platformfs-all images-all-sbc images-all-cloud
 
@@ -64,19 +87,25 @@ images-all-print:
 	@echo $(ALL_SBC_IMAGES) $(ALL_CLOUD_IMAGES) | sed "s: :\n:g"
 
 void-%-$(DATECODE).img.xz: void-%-PLATFORMFS-$(DATECODE).tar.xz
+	@[ -n "${CI}" ] && printf "::group::\x1b[32mBuilding $@...\x1b[0m\n" || true
 	$(SUDO) ./mkimage.sh -x $(COMPRESSOR_THREADS) void-$*-PLATFORMFS-$(DATECODE).tar.xz
+	@[ -n "${CI}" ] && printf '::endgroup::\n' || true
 
 # Some of the images MUST be compressed with gzip rather than xz, this
 # rule services those images.
 void-%-$(DATECODE).tar.gz: void-%-PLATFORMFS-$(DATECODE).tar.xz
+	@[ -n "${CI}" ] && printf "::group::\x1b[32mBuilding $@...\x1b[0m\n" || true
 	$(SUDO) ./mkimage.sh -x $(COMPRESSOR_THREADS) void-$*-PLATFORMFS-$(DATECODE).tar.xz
+	@[ -n "${CI}" ] && printf '::endgroup::\n' || true
 
 pxe-all: $(ALL_PXE_ARCHS)
 
 pxe-all-print:
 	@echo $(ALL_PXE_ARCHS) | sed "s: :\n:g"
 
-void-%-NETBOOT-$(DATECODE).tar.gz: $(SCRIPTS) void-%-ROOTFS-$(DATECODE).tar.xz
+void-%-NETBOOT-$(DATECODE).tar.gz: void-%-ROOTFS-$(DATECODE).tar.xz
+	@[ -n "${CI}" ] && printf "::group::\x1b[32mBuilding $@...\x1b[0m\n" || true
 	$(SUDO) ./mknet.sh void-$*-ROOTFS-$(DATECODE).tar.xz
+	@[ -n "${CI}" ] && printf '::endgroup::\n' || true
 
-.PHONY: all dist rootfs-all-print rootfs-all platformfs-all-print platformfs-all pxe-all-print pxe-all
+.PHONY: all checksum dist live-iso-all live-iso-all-print rootfs-all-print rootfs-all platformfs-all-print platformfs-all pxe-all-print pxe-all

--- a/build-x86-images.sh
+++ b/build-x86-images.sh
@@ -7,19 +7,22 @@ set -eu
 PROGNAME=$(basename "$0")
 ARCH=$(uname -m)
 IMAGES="base enlightenment xfce mate cinnamon gnome kde lxde lxqt"
+TRIPLET=
 REPO=
-DATE=$(date +%Y%m%d)
+DATE=$(date -u +%Y%m%d)
 
 help() {
-    echo "$PROGNAME: [-a arch] [-b base|enlightenment|xfce|mate|cinnamon|gnome|kde|lxde|lxqt] [-r repo]" >&2
+    echo "$PROGNAME: [-a arch] [-b base|enlightenment|xfce|mate|cinnamon|gnome|kde|lxde|lxqt] [-d date] [-t arch-date-variant] [-r repo]" >&2
 }
 
-while getopts "a:b:hr:V" opt; do
+while getopts "a:b:d:t:hr:V" opt; do
 case $opt in
     a) ARCH="$OPTARG";;
     b) IMAGES="$OPTARG";;
+    d) DATE="$OPTARG";;
     h) help; exit 0;;
     r) REPO="-r $OPTARG $REPO";;
+    t) TRIPLET="$OPTARG";;
     V) version; exit 0;;
     *) help; exit 1;;
 esac
@@ -116,6 +119,14 @@ else
     exit 1
 fi
 
-for image in $IMAGES; do
-    build_variant "$image" "$@"
-done
+if [ -n "$TRIPLET" ]; then
+    VARIANT="${TRIPLET##*-}"
+    REST="${TRIPLET%-*}"
+    DATE="${REST##*-}"
+    ARCH="${REST%-*}"
+    build_variant "$VARIANT" "$@"
+else
+    for image in $IMAGES; do
+        build_variant "$image" "$@"
+    done
+fi


### PR DESCRIPTION
Whether this is actually viable is currently unknown, the generated images have not been tested. an example run is [available here](https://github.com/classabbyamp/void-mklive/actions/runs/4648628064).

[images are available to test here](https://devspace.voidlinux.org/abby/live/)

- currently only manual triggering, but maybe we'd want to do this on tag/release?
- This will take probably ~2 hours to run to completion
    - it would be nice to parallelise some of this, but sbc images require platformfses which require rootfses, so *some* of it has to be sequential
    - also, to get everything in the same artifact, I don't think we can use `matrix` jobs
- SBC images were failing, so that hasn't been tested yet
    - lots of stuff needs testing here, it was taking too long to let everything build every time
- end result should be a `.zip`'d artifact file on the CI run, with all requested images built and a sha256sum.txt file included, ready for signing
- built items are configurable, but you may get some bonus things like a ROOTFS and PLATFORMFS if you request a SBC image only

![image](https://user-images.githubusercontent.com/5366828/230761937-8f69655d-6a40-453d-bff6-407c103b1bad.png)

cc @the-maldridge
