### PR TITLE
autoinstaller: wrap dracut calls so they can error

### DIFF
--- a/dracut/autoinstaller/install.sh
+++ b/dracut/autoinstaller/install.sh
@@ -2,6 +2,18 @@
 
 set -e
 
+# These are for all you erroring dracuts out there
+VAI_getarg() {
+	set +e
+	getarg "$@"
+	set -e
+}
+VAI_getargbool() {
+	set +e
+	getargbool "$@"
+	set -e
+}
+
 # These functions pulled from void's excellent mklive.sh
 VAI_info_msg() {
     printf "\033[1m%s\n\033[m" "$@"
@@ -212,8 +224,8 @@ VAI_configure_autoinstall() {
     esac
 
     # --------------- Pull config URL out of kernel cmdline -------------------------
-    if getargbool 0 autourl ; then
-        xbps-uhelper fetch "$(getarg autourl)>/etc/autoinstall.cfg"
+    if VAI_getargbool 0 autourl ; then
+        xbps-uhelper fetch "$(VAI_getarg autourl)>/etc/autoinstall.cfg"
 
     else
         mv /etc/autoinstall.default /etc/autoinstall.cfg
@@ -288,7 +300,7 @@ VAI_main() {
 }
 
 # If we are using the autoinstaller, launch it
-if getargbool 0 auto  ; then
+if VAI_getargbool 0 auto  ; then
     VAI_main
 fi
 


### PR DESCRIPTION
It's nice that our stuff can be set -e but this is a regression on dracut's side that these calls are no longer safe under `set -e`.

Validated this fixes my autoinstaller problems.

Picture of a screen for the difference in call stack:

![Showing a `getarg` call with and without set -e](https://files.catbox.moe/xax4ba.heic)
![Showing that this doesn't work under `set -e`](https://files.catbox.moe/8k0kw5.jpg)