### PR TITLE
accessibility improvements, memtest86+, bootloader menu improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ that can change the behavior of the live system:
 - `live.autologin` will skip the initial login screen on `tty1`.
 - `live.user` will change the username of the non-root user from the default `anon`. The password remains `voidlinux`.
 - `live.shell` sets the default shell for the non-root user in the live environment.
-- `live.screenreader` enables the console screenreader `espeakup` in the live environment.
+- `live.accessibility` enables accessibility features like the console screenreader `espeakup` in the live environment.
 - `console` can be set to `ttyS0`, `hvc0`, or `hvsi0` to enable `agetty` on that serial console.
 - `locale.LANG` will set the `LANG` environment variable. Defaults to `en_US.UTF-8`.
 - `vconsole.keymap` will set the console keymap. Defaults to `us`.

--- a/build-x86-images.sh
+++ b/build-x86-images.sh
@@ -41,7 +41,8 @@ build_variant() {
     shift
     IMG=void-live-${ARCH}-${DATE}-${variant}.iso
     GRUB_PKGS="grub-i386-efi grub-x86_64-efi"
-    PKGS="dialog cryptsetup lvm2 mdadm void-docs-browse xtools-minimal xmirror espeakup $GRUB_PKGS"
+    A11Y_PKGS="espeakup void-live-audio"
+    PKGS="dialog cryptsetup lvm2 mdadm void-docs-browse xtools-minimal xmirror $A11Y_PKGS $GRUB_PKGS"
     XORG_PKGS="xorg-minimal xorg-input-drivers xorg-video-drivers setxkbmap xauth font-misc-misc terminus-font dejavu-fonts-ttf alsa-plugins-pulseaudio"
     SERVICES="sshd"
 

--- a/build-x86-images.sh
+++ b/build-x86-images.sh
@@ -36,6 +36,18 @@ cleanup() {
     rm -r "$INCLUDEDIR"
 }
 
+setup_pipewire() {
+    PKGS="$PKGS pipewire alsa-pipewire"
+    mkdir -p "$INCLUDEDIR"/etc/xdg/autostart
+    ln -s /usr/share/applications/pipewire.desktop "$INCLUDEDIR"/etc/xdg/autostart/
+    mkdir -p "$INCLUDEDIR"/etc/pipewire/pipewire.conf.d
+    ln -s /usr/share/examples/wireplumber/10-wireplumber.conf "$INCLUDEDIR"/etc/pipewire/pipewire.conf.d/
+    ln -s /usr/share/examples/pipewire/20-pipewire-pulse.conf "$INCLUDEDIR"/etc/pipewire/pipewire.conf.d/
+    mkdir -p "$INCLUDEDIR"/etc/alsa/conf.d
+    ln -s /usr/share/alsa/alsa.conf.d/50-pipewire.conf "$INCLUDEDIR"/etc/alsa/conf.d
+    ln -s /usr/share/alsa/alsa.conf.d/99-pipewire-default.conf "$INCLUDEDIR"/etc/alsa/conf.d
+}
+
 build_variant() {
     variant="$1"
     shift
@@ -43,7 +55,7 @@ build_variant() {
     GRUB_PKGS="grub-i386-efi grub-x86_64-efi"
     A11Y_PKGS="espeakup void-live-audio brltty"
     PKGS="dialog cryptsetup lvm2 mdadm void-docs-browse xtools-minimal xmirror $A11Y_PKGS $GRUB_PKGS"
-    XORG_PKGS="xorg-minimal xorg-input-drivers xorg-video-drivers setxkbmap xauth font-misc-misc terminus-font dejavu-fonts-ttf alsa-plugins-pulseaudio"
+    XORG_PKGS="xorg-minimal xorg-input-drivers xorg-video-drivers setxkbmap xauth font-misc-misc terminus-font dejavu-fonts-ttf"
     SERVICES="sshd"
 
     LIGHTDM_SESSION=''
@@ -58,7 +70,7 @@ build_variant() {
             LIGHTDM_SESSION=enlightenment
         ;;
         xfce)
-            PKGS="$PKGS $XORG_PKGS lightdm lightdm-gtk3-greeter xfce4 gnome-themes-standard gnome-keyring network-manager-applet gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox"
+            PKGS="$PKGS $XORG_PKGS lightdm lightdm-gtk3-greeter xfce4 gnome-themes-standard gnome-keyring network-manager-applet gvfs-afc gvfs-mtp gvfs-smb udisks2 firefox xfce4-pulseaudio-plugin"
             SERVICES="$SERVICES dbus elogind lightdm NetworkManager polkitd"
             LIGHTDM_SESSION=xfce
         ;;
@@ -98,6 +110,10 @@ build_variant() {
     if [ -n "$LIGHTDM_SESSION" ]; then
         mkdir -p "$INCLUDEDIR"/etc/lightdm
         echo "$LIGHTDM_SESSION" > "$INCLUDEDIR"/etc/lightdm/.session
+    fi
+
+    if [ "$variant" != base ]; then
+        setup_pipewire
     fi
 
     ./mklive.sh -a "$ARCH" -o "$IMG" -p "$PKGS" -S "$SERVICES" -I "$INCLUDEDIR" ${REPO} "$@"

--- a/build-x86-images.sh
+++ b/build-x86-images.sh
@@ -41,7 +41,6 @@ build_variant() {
     shift
     IMG=void-live-${ARCH}-${DATE}-${variant}.iso
     GRUB_PKGS="grub-i386-efi grub-x86_64-efi"
-    PKGS="dialog cryptsetup lvm2 mdadm void-docs-browse xtools-minimal xmirror $GRUB_PKGS"
     PKGS="dialog cryptsetup lvm2 mdadm void-docs-browse xtools-minimal xmirror espeakup $GRUB_PKGS"
     XORG_PKGS="xorg-minimal xorg-input-drivers xorg-video-drivers setxkbmap xauth font-misc-misc terminus-font dejavu-fonts-ttf alsa-plugins-pulseaudio"
     SERVICES="sshd"

--- a/build-x86-images.sh
+++ b/build-x86-images.sh
@@ -55,7 +55,7 @@ build_variant() {
     GRUB_PKGS="grub-i386-efi grub-x86_64-efi"
     A11Y_PKGS="espeakup void-live-audio brltty"
     PKGS="dialog cryptsetup lvm2 mdadm void-docs-browse xtools-minimal xmirror $A11Y_PKGS $GRUB_PKGS"
-    XORG_PKGS="xorg-minimal xorg-input-drivers xorg-video-drivers setxkbmap xauth font-misc-misc terminus-font dejavu-fonts-ttf"
+    XORG_PKGS="xorg-minimal xorg-input-drivers xorg-video-drivers setxkbmap xauth font-misc-misc terminus-font dejavu-fonts-ttf orca"
     SERVICES="sshd"
 
     LIGHTDM_SESSION=''

--- a/build-x86-images.sh
+++ b/build-x86-images.sh
@@ -41,7 +41,7 @@ build_variant() {
     shift
     IMG=void-live-${ARCH}-${DATE}-${variant}.iso
     GRUB_PKGS="grub-i386-efi grub-x86_64-efi"
-    A11Y_PKGS="espeakup void-live-audio"
+    A11Y_PKGS="espeakup void-live-audio brltty"
     PKGS="dialog cryptsetup lvm2 mdadm void-docs-browse xtools-minimal xmirror $A11Y_PKGS $GRUB_PKGS"
     XORG_PKGS="xorg-minimal xorg-input-drivers xorg-video-drivers setxkbmap xauth font-misc-misc terminus-font dejavu-fonts-ttf alsa-plugins-pulseaudio"
     SERVICES="sshd"

--- a/dracut/vmklive/accessibility.sh
+++ b/dracut/vmklive/accessibility.sh
@@ -4,6 +4,6 @@
 
 type getargbool >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
-if getargbool 0 live.screenreader && [ -d "${NEWROOT}/etc/sv/espeakup" ]; then
+if getargbool 0 live.accessibility && [ -d "${NEWROOT}/etc/sv/espeakup" ]; then
 	ln -s /etc/sv/espeakup "${NEWROOT}/etc/runit/runsvdir/current/"
 fi

--- a/dracut/vmklive/accessibility.sh
+++ b/dracut/vmklive/accessibility.sh
@@ -4,6 +4,7 @@
 
 type getargbool >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
-if getargbool 0 live.accessibility && [ -d "${NEWROOT}/etc/sv/espeakup" ]; then
-	ln -s /etc/sv/espeakup "${NEWROOT}/etc/runit/runsvdir/current/"
+if getargbool 0 live.accessibility; then
+    [ -d "${NEWROOT}/etc/sv/espeakup" ] && ln -s "/etc/sv/espeakup" "${NEWROOT}/etc/runit/runsvdir/current/"
+    [ -d "${NEWROOT}/etc/sv/brltty" ] && ln -s "/etc/sv/brltty" "${NEWROOT}/etc/runit/runsvdir/current/"
 fi

--- a/dracut/vmklive/module-setup.sh
+++ b/dracut/vmklive/module-setup.sh
@@ -27,5 +27,5 @@ install() {
     inst_hook pre-pivot 02 "$moddir/display-manager-autologin.sh"
     inst_hook pre-pivot 02 "$moddir/getty-serial.sh"
     inst_hook pre-pivot 03 "$moddir/locale.sh"
-    inst_hook pre-pivot 04 "$moddir/screenreader.sh"
+    inst_hook pre-pivot 04 "$moddir/accessibility.sh"
 }

--- a/grub/grub_void.cfg.in
+++ b/grub/grub_void.cfg.in
@@ -3,44 +3,94 @@ set pager="1"
 set locale_dir="(${voidlive})/boot/grub/locale"
 
 if [ -e "${prefix}/${grub_cpu}-${grub_platform}/all_video.mod" ]; then
-    insmod all_video
+	insmod all_video
 else
-    insmod efi_gop
-    insmod efi_uga
-    insmod video_bochs
-    insmod video_cirrus
+	insmod efi_gop
+	insmod efi_uga
+	insmod video_bochs
+	insmod video_cirrus
 fi
 
 insmod font
 
 if loadfont "(${voidlive})/boot/grub/fonts/unicode.pf2" ; then
-    insmod gfxterm
-    set gfxmode="auto"
-    
-    terminal_input console
-    terminal_output gfxterm
-    
-    insmod png
-    background_image "(${voidlive})/boot/isolinux/@@SPLASHIMAGE@@"
+	insmod gfxterm
+	set gfxmode="auto"
+
+	terminal_input console
+	terminal_output gfxterm
+
+	insmod png
+	background_image "(${voidlive})/boot/isolinux/@@SPLASHIMAGE@@"
 fi
 
+# Set default menu entry
+default=linux
+timeout=15
+timeout_style=menu
+
+# GRUB init tune for accessibility
+play 600 988 1 1319 4
+
 if [ cpuid -l ]; then
-    menuentry "@@BOOT_TITLE@@ @@KERNVER@@ (@@ARCH@@)" {
-        set gfxpayload="keep"
-        linux (${voidlive})/boot/vmlinuz \
+	menuentry "@@BOOT_TITLE@@ @@KERNVER@@ (@@ARCH@@)" --id "linux" {
+		set gfxpayload="keep"
+		linux (${voidlive})/boot/vmlinuz \
 		root=live:CDLABEL=VOID_LIVE ro init=/sbin/init \
 		rd.luks=0 rd.md=0 rd.dm=0 loglevel=4 gpt add_efi_memmap \
 		vconsole.unicode=1 vconsole.keymap=@@KEYMAP@@ \
 		locale.LANG=@@LOCALE@@ @@BOOT_CMDLINE@@
-        initrd (${voidlive})/boot/initrd
-    }
-    menuentry "@@BOOT_TITLE@@ @@KERNVER@@ (@@ARCH@@) (RAM)" {
-        set gfxpayload="keep"
-        linux (${voidlive})/boot/vmlinuz \
+		initrd (${voidlive})/boot/initrd
+	}
+	menuentry "@@BOOT_TITLE@@ @@KERNVER@@ (@@ARCH@@) (RAM)" --id "linuxram" {
+		set gfxpayload="keep"
+		linux (${voidlive})/boot/vmlinuz \
 		root=live:CDLABEL=VOID_LIVE ro init=/sbin/init \
 		rd.luks=0 rd.md=0 rd.dm=0 loglevel=4 gpt add_efi_memmap \
 		vconsole.unicode=1 vconsole.keymap=@@KEYMAP@@ \
 		locale.LANG=@@LOCALE@@ @@BOOT_CMDLINE@@ rd.live.ram
-        initrd (${voidlive})/boot/initrd
-    }
+		initrd (${voidlive})/boot/initrd
+	}
+	menuentry "@@BOOT_TITLE@@ @@KERNVER@@ (@@ARCH@@) with speech" --hotkey s --id "linuxa11y" {
+		set gfxpayload="keep"
+		linux (${voidlive})/boot/vmlinuz \
+		root=live:CDLABEL=VOID_LIVE ro init=/sbin/init \
+		rd.luks=0 rd.md=0 rd.dm=0 loglevel=4 gpt add_efi_memmap \
+		vconsole.unicode=1 vconsole.keymap=@@KEYMAP@@ \
+		locale.LANG=@@LOCALE@@ @@BOOT_CMDLINE@@ live.accessibility live.autologin
+		initrd (${voidlive})/boot/initrd
+	}
+	menuentry "@@BOOT_TITLE@@ @@KERNVER@@ (@@ARCH@@) with speech (RAM)" --hotkey r --id "linuxa11yram" {
+		set gfxpayload="keep"
+		linux (${voidlive})/boot/vmlinuz \
+		root=live:CDLABEL=VOID_LIVE ro init=/sbin/init \
+		rd.luks=0 rd.md=0 rd.dm=0 loglevel=4 gpt add_efi_memmap \
+		vconsole.unicode=1 vconsole.keymap=@@KEYMAP@@ \
+		locale.LANG=@@LOCALE@@ @@BOOT_CMDLINE@@ live.accessibility live.autologin rd.live.ram
+		initrd (${voidlive})/boot/initrd
+	}
+	if [ "${grub_platform}" == "efi" ]; then
+		menuentry "Run Memtest86+ (RAM test)" --id memtest {
+			set gfxpayload="keep"
+			linux (${voidlive})/boot/memtest.efi
+		}
+		menuentry 'UEFI Firmware Settings' --id uefifw {
+			fwsetup
+		}
+	else
+		menuentry "Run Memtest86+ (RAM test)" --id memtest {
+			set gfxpayload="keep"
+			linux (${voidlive})/boot/memtest.bin
+		}
+	fi
+
+	menuentry "System restart" --id restart {
+		echo "System rebooting..."
+		reboot
+	}
+
+	menuentry "System shutdown" --id poweroff {
+		echo "System shutting down..."
+		halt
+	}
 fi

--- a/installer.sh
+++ b/installer.sh
@@ -1325,9 +1325,12 @@ ${BOLD}Do you want to continue?${RESET}" 20 80 || return
         INFOBOX "Removing temporary packages from target ..." 4 60
         echo "Removing temporary packages from target ..." >$LOG
         TO_REMOVE="dialog xtools-minimal"
-        # only remove espeakup if it wasn't enabled in the live environment
+        # only remove espeakup and brltty if it wasn't enabled in the live environment
         if ! [ -e "/var/service/espeakup" ]; then
             TO_REMOVE+=" espeakup"
+        fi
+        if ! [ -e "/var/service/brltty" ]; then
+            TO_REMOVE+=" brltty"
         fi
         xbps-remove -r $TARGETDIR -Ry $TO_REMOVE >>$LOG 2>&1
         rmdir $TARGETDIR/mnt/target

--- a/isolinux/isolinux.cfg.in
+++ b/isolinux/isolinux.cfg.in
@@ -1,6 +1,6 @@
 UI vesamenu.c32
 PROMPT 0
-TIMEOUT 100
+TIMEOUT 150
 ONTIMEOUT linux
 
 MENU TABMSG Press ENTER to boot or TAB to edit a menu entry
@@ -8,13 +8,13 @@ MENU AUTOBOOT BIOS default device boot in # second{,s}...
 MENU BACKGROUND @@SPLASHIMAGE@@
 MENU WIDTH 78
 MENU MARGIN 1
-MENU ROWS 4
+MENU ROWS 9
 MENU VSHIFT 2
-MENU TIMEOUTROW 8
+MENU TIMEOUTROW 13
 MENU TABMSGROW 2
-MENU CMDLINEROW 11
-MENU HELPMSGROW 16
-MENU HELPMSGENDROW 29
+MENU CMDLINEROW 16
+MENU HELPMSGROW 20
+MENU HELPMSGENDROW 34
 
 MENU COLOR title        * #FF5255FF *
 MENU COLOR border       * #00000000 #00000000 none
@@ -24,11 +24,35 @@ LABEL linux
 MENU LABEL @@BOOT_TITLE@@ @@KERNVER@@ @@ARCH@@
 KERNEL /boot/vmlinuz
 APPEND initrd=/boot/initrd root=live:CDLABEL=VOID_LIVE init=/sbin/init ro rd.luks=0 rd.md=0 rd.dm=0 loglevel=4 vconsole.unicode=1 vconsole.keymap=@@KEYMAP@@ locale.LANG=@@LOCALE@@ @@BOOT_CMDLINE@@
+
 LABEL linuxram
 MENU LABEL @@BOOT_TITLE@@ @@KERNVER@@ @@ARCH@@ (RAM)
 KERNEL /boot/vmlinuz
 APPEND initrd=/boot/initrd root=live:CDLABEL=VOID_LIVE init=/sbin/init ro rd.luks=0 rd.md=0 rd.dm=0 loglevel=4 vconsole.unicode=1 vconsole.keymap=@@KEYMAP@@ locale.LANG=@@LOCALE@@ @@BOOT_CMDLINE@@ rd.live.ram
+
+LABEL linuxa11y
+MENU LABEL @@BOOT_TITLE@@ @@KERNVER@@ @@ARCH@@ with ^speech
+KERNEL /boot/vmlinuz
+APPEND initrd=/boot/initrd root=live:CDLABEL=VOID_LIVE init=/sbin/init ro rd.luks=0 rd.md=0 rd.dm=0 loglevel=4 vconsole.unicode=1 vconsole.keymap=@@KEYMAP@@ locale.LANG=@@LOCALE@@ @@BOOT_CMDLINE@@ live.accessibility live.autologin
+
+LABEL linuxa11yram
+MENU LABEL @@BOOT_TITLE@@ @@KERNVER@@ @@ARCH@@ with speech (^RAM)
+KERNEL /boot/vmlinuz
+APPEND initrd=/boot/initrd root=live:CDLABEL=VOID_LIVE init=/sbin/init ro rd.luks=0 rd.md=0 rd.dm=0 loglevel=4 vconsole.unicode=1 vconsole.keymap=@@KEYMAP@@ locale.LANG=@@LOCALE@@ @@BOOT_CMDLINE@@ live.accessibility live.autologin rd.live.ram
+
 LABEL c
 MENU LABEL Boot first HD found by BIOS
 COM32 chain.c32
 APPEND hd0
+
+LABEL memtest
+MENU LABEL Run Memtest86+ (RAM test)
+LINUX /boot/memtest.bin
+
+LABEL reboot
+MENU LABEL Reboot
+COM32 reboot.c32
+
+LABEL poweroff
+MENU LABEL Power Off
+COM32 poweroff.c32

--- a/mklive.sh
+++ b/mklive.sh
@@ -31,7 +31,7 @@ umask 022
 
 . ./lib.sh
 
-readonly REQUIRED_PKGS="base-files libgcc dash coreutils sed tar gawk syslinux grub-i386-efi grub-x86_64-efi squashfs-tools xorriso"
+readonly REQUIRED_PKGS="base-files libgcc dash coreutils sed tar gawk syslinux grub-i386-efi grub-x86_64-efi memtest86+ squashfs-tools xorriso"
 readonly INITRAMFS_PKGS="binutils xz device-mapper dhclient dracut-network openresolv"
 readonly PROGNAME=$(basename "$0")
 declare -a INCLUDE_DIRS=()
@@ -189,6 +189,8 @@ generate_isolinux_boot() {
     cp -f "$SYSLINUX_DATADIR"/vesamenu.c32 "$ISOLINUX_DIR"
     cp -f "$SYSLINUX_DATADIR"/libutil.c32 "$ISOLINUX_DIR"
     cp -f "$SYSLINUX_DATADIR"/chain.c32 "$ISOLINUX_DIR"
+    cp -f "$SYSLINUX_DATADIR"/reboot.c32 "$ISOLINUX_DIR"
+    cp -f "$SYSLINUX_DATADIR"/poweroff.c32 "$ISOLINUX_DIR"
     cp -f isolinux/isolinux.cfg.in "$ISOLINUX_DIR"/isolinux.cfg
     cp -f ${SPLASH_IMAGE} "$ISOLINUX_DIR"
 
@@ -200,6 +202,9 @@ generate_isolinux_boot() {
         -e "s|@@BOOT_TITLE@@|${BOOT_TITLE}|" \
         -e "s|@@BOOT_CMDLINE@@|${BOOT_CMDLINE}|" \
         "$ISOLINUX_DIR"/isolinux.cfg
+
+    # include memtest86+
+    cp -f "$VOIDHOSTDIR"/boot/memtest.bin "$BOOT_DIR"
 }
 
 generate_grub_efi_boot() {
@@ -252,6 +257,9 @@ generate_grub_efi_boot() {
     umount "$GRUB_EFI_TMPDIR"
     losetup --detach "${LOOP_DEVICE}"
     rm -rf "$GRUB_EFI_TMPDIR"
+
+    # include memtest86+
+    cp -f "$VOIDHOSTDIR"/boot/memtest.efi "$BOOT_DIR"
 }
 
 generate_squashfs() {


### PR DESCRIPTION
bootloader improvements:
- mklive: add memtest86+ to images
    - closes #346 
- isolinux: add menu entries for screenreader, memtest, reboot, poweroff
- grub: add menu entries for screenreader, memtest, efi fw setup, reboot, poweroff

a11y improvements:
- dracut/vmklive: rename live.screenreader to live.accessibility
- build-x86-images.sh: add void-live-audio for a11y audio setup
- build-x86-images, dracut/vmklive, installer: add support for brltty
- build-x86-images: add orca, graphical screenreader
- closes #345 

misc:
- build-x86-images: remove duplicate line
- build-x86-images.sh: switch to pipewire on non-base images
    - closes #301 
