### PR TITLE
build-x86-images: show keymap selector in lightdm greeter

### DIFF
--- a/build-x86-images.sh
+++ b/build-x86-images.sh
@@ -110,6 +110,11 @@ build_variant() {
     if [ -n "$LIGHTDM_SESSION" ]; then
         mkdir -p "$INCLUDEDIR"/etc/lightdm
         echo "$LIGHTDM_SESSION" > "$INCLUDEDIR"/etc/lightdm/.session
+        # needed to show the keyboard layout menu on the login screen
+        cat <<- EOF > "$INCLUDEDIR"/etc/lightdm/lightdm-gtk-greeter.conf
+[greeter]
+indicators = ~host;~spacer;~clock;~spacer;~layout;~session;~a11y;~power
+EOF
     fi
 
     if [ "$variant" != base ]; then


### PR DESCRIPTION
fixes #353
