### PR TITLE
mkimage: use PARTUUID for root on rpi* images

### DIFF
--- a/mkimage.sh
+++ b/mkimage.sh
@@ -256,6 +256,10 @@ sed -i "${ROOTFS}/etc/ssh/sshd_config" -e 's|^#\(PermitRootLogin\) .*|\1 yes|g'
 # can be found.
 info_msg "Configuring image for platform $PLATFORM"
 case "$PLATFORM" in
+rpi*)
+	# use PARTUUID to allow for non-mmc boot without configuration
+	sed -i "s/root=[^ ]*/root=PARTUUID=${ROOT_PARTUUID}/" "${ROOTFS}/boot/cmdline.txt"
+	;;
 rock64*)
     rk33xx_flash_uboot "${ROOTFS}/usr/lib/rock64-uboot" "$LOOPDEV"
     # populate the extlinux.conf file


### PR DESCRIPTION
This makes it easier to set up an RPi SBC image for non-MMC boot by ensuring that the right root partition is chosen. If the enumerated (sdX-style) name changes, boot can fail.

using plain UUID does not work because the kernel cannot find that itself, it would need udev/an initrd.

tested on RPi 4 with USB boot so far
