### PR TITLE
[RFC] grub/, isolinux/: always enable autologin

### DIFF
--- a/grub/grub_void.cfg.in
+++ b/grub/grub_void.cfg.in
@@ -39,7 +39,7 @@ if [ cpuid -l ]; then
 		root=live:CDLABEL=VOID_LIVE ro init=/sbin/init \
 		rd.luks=0 rd.md=0 rd.dm=0 loglevel=4 gpt add_efi_memmap \
 		vconsole.unicode=1 vconsole.keymap=@@KEYMAP@@ \
-		locale.LANG=@@LOCALE@@ @@BOOT_CMDLINE@@
+		locale.LANG=@@LOCALE@@ @@BOOT_CMDLINE@@ live.autologin
 		initrd (${voidlive})/boot/initrd
 	}
 	menuentry "@@BOOT_TITLE@@ @@KERNVER@@ (@@ARCH@@) (RAM)" --id "linuxram" {
@@ -48,7 +48,7 @@ if [ cpuid -l ]; then
 		root=live:CDLABEL=VOID_LIVE ro init=/sbin/init \
 		rd.luks=0 rd.md=0 rd.dm=0 loglevel=4 gpt add_efi_memmap \
 		vconsole.unicode=1 vconsole.keymap=@@KEYMAP@@ \
-		locale.LANG=@@LOCALE@@ @@BOOT_CMDLINE@@ rd.live.ram
+		locale.LANG=@@LOCALE@@ @@BOOT_CMDLINE@@ live.autologin rd.live.ram
 		initrd (${voidlive})/boot/initrd
 	}
 	menuentry "@@BOOT_TITLE@@ @@KERNVER@@ (@@ARCH@@) with speech" --hotkey s --id "linuxa11y" {

--- a/isolinux/isolinux.cfg.in
+++ b/isolinux/isolinux.cfg.in
@@ -23,12 +23,12 @@ MENU COLOR sel          * #ffffffff #FF5255FF *
 LABEL linux
 MENU LABEL @@BOOT_TITLE@@ @@KERNVER@@ @@ARCH@@
 KERNEL /boot/vmlinuz
-APPEND initrd=/boot/initrd root=live:CDLABEL=VOID_LIVE init=/sbin/init ro rd.luks=0 rd.md=0 rd.dm=0 loglevel=4 vconsole.unicode=1 vconsole.keymap=@@KEYMAP@@ locale.LANG=@@LOCALE@@ @@BOOT_CMDLINE@@
+APPEND initrd=/boot/initrd root=live:CDLABEL=VOID_LIVE init=/sbin/init ro rd.luks=0 rd.md=0 rd.dm=0 loglevel=4 vconsole.unicode=1 vconsole.keymap=@@KEYMAP@@ locale.LANG=@@LOCALE@@ @@BOOT_CMDLINE@@ live.autologin
 
 LABEL linuxram
 MENU LABEL @@BOOT_TITLE@@ @@KERNVER@@ @@ARCH@@ (RAM)
 KERNEL /boot/vmlinuz
-APPEND initrd=/boot/initrd root=live:CDLABEL=VOID_LIVE init=/sbin/init ro rd.luks=0 rd.md=0 rd.dm=0 loglevel=4 vconsole.unicode=1 vconsole.keymap=@@KEYMAP@@ locale.LANG=@@LOCALE@@ @@BOOT_CMDLINE@@ rd.live.ram
+APPEND initrd=/boot/initrd root=live:CDLABEL=VOID_LIVE init=/sbin/init ro rd.luks=0 rd.md=0 rd.dm=0 loglevel=4 vconsole.unicode=1 vconsole.keymap=@@KEYMAP@@ locale.LANG=@@LOCALE@@ @@BOOT_CMDLINE@@ live.autologin rd.live.ram
 
 LABEL linuxa11y
 MENU LABEL @@BOOT_TITLE@@ @@KERNVER@@ @@ARCH@@ with ^speech


### PR DESCRIPTION
I know in the past there has been some opposition to this, but I don't feel that the reasons brought up are enough to not do this. I do agree that void shouldn't do this *just because other distros do*, but it should be fine to do this for other reasons, namely **convenience** (not having to log in to do an install) and **consistency** (keeping the experience similar between base and graphical flavours).

closes #137
