### PR TITLE
installer.sh: add users to default groups, ignore nogroup and chrony groups

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -744,7 +744,7 @@ menu_useraccount() {
         fi
     done
 
-    _groups="wheel,audio,video,floppy,cdrom,optical,kvm,xbuilder"
+    _groups="wheel,audio,video,floppy,cdrom,optical,kvm,users,xbuilder"
     while true; do
         _desc="Select group membership for login '$(get_option USERLOGIN)':"
         for _group in $(cat /etc/group); do
@@ -757,7 +757,7 @@ menu_useraccount() {
                 _status=on
             fi
             # ignore the groups of root, existing users, and package groups
-            if [[ "${_gid}" -ge 1000 || "${_group}" = "_"* || "${_group}" = "root" ]]; then
+            if [[ "${_gid}" -ge 1000 || "${_group}" = "_"* || "${_group}" =~ ^(root|nogroup|chrony|dbus|lightdm|polkitd)$ ]]; then
                 continue
             fi
             if [ -z "${_checklist}" ]; then


### PR DESCRIPTION
no reason to show these groups, and `users` is a common enough group to want to have, I think (e.g. it gives access to yubikeys)