### PR TITLE
Use pseudofs functions already defined in lib.sh

### DIFF
--- a/mklive.sh
+++ b/mklive.sh
@@ -47,22 +47,6 @@ print_step() {
     info_msg "[${CURRENT_STEP}/${STEP_COUNT}] $*"
 }
 
-mount_pseudofs() {
-    for f in sys dev proc; do
-        mkdir -p "$ROOTFS"/$f
-        mount --rbind /$f "$ROOTFS"/$f
-    done
-}
-
-umount_pseudofs() {
-	for f in sys dev proc; do
-		if [ -d "$ROOTFS/$f" ] && ! umount -R -f "$ROOTFS/$f"; then
-			info_msg "ERROR: failed to unmount $ROOTFS/$f/"
-			return 1
-		fi
-	done
-}
-
 error_out() {
 	trap - INT TERM 0
     umount_pseudofs || exit "${1:-0}"


### PR DESCRIPTION
The current `mount_pseudofs()` and `umount_psuedofs()` functions don't always allow umount to work properly.
The following errors are resolved by using the `mount_pseudofs()` and `umount_psuedofs()` functions from lib.sh.
The current functions are very similar to the ones in lib.sh so it seems like a useful change.
The lib.sh functions were updated in https://github.com/void-linux/void-mklive/pull/245 to include `--make-rslave` which resolved these issues in the past for other scripts.

```
[10/11] Generating squashfs image (xz) from rootfs...
umount: /home/tsandqui/Code/void-mklive/mklive-build.lWvxd/image/rootfs/sys/fs/cgroup: target is busy.
ERROR: failed to unmount /home/tsandqui/Code/void-mklive/mklive-build.lWvxd/image/rootfs/sys/
umount: /home/tsandqui/Code/void-mklive/mklive-build.lWvxd/image/rootfs/sys/fs/cgroup: target is busy.
ERROR: failed to unmount /home/tsandqui/Code/void-mklive/mklive-build.lWvxd/image/rootfs/sys/
```