### PR TITLE
dracut/autoinstaller: Fix device race conditions

### DIFF
--- a/dracut/autoinstaller/install.sh
+++ b/dracut/autoinstaller/install.sh
@@ -21,6 +21,13 @@ VAI_welcome() {
     printf "=============================================================\n"
 }
 
+VAI_udev_settle() {
+    /usr/bin/udevd --daemon
+    /usr/bin/udevadm trigger --action=add --type=subsystems
+    /usr/bin/udevadm trigger --action=add --type=devices
+    /usr/bin/udevadm settle
+}
+
 VAI_get_address() {
     mkdir -p /var/lib/dhclient
 
@@ -236,9 +243,12 @@ VAI_configure_autoinstall() {
 
 VAI_main() {
     CURRENT_STEP=0
-    STEP_COUNT=16
+    STEP_COUNT=17
 
     VAI_welcome
+
+    VAI_print_step "Wait on hardware"
+    VAI_udev_settle
 
     VAI_print_step "Bring up the network"
     VAI_get_address

--- a/dracut/autoinstaller/module-setup.sh
+++ b/dracut/autoinstaller/module-setup.sh
@@ -40,5 +40,6 @@ install() {
     inst /etc/ssl/certs.pem
 
     inst_hook pre-mount 01 "$moddir/install.sh"
+    inst_hook cmdline 99 "$moddir/parse-vai-root.sh"
     inst "$moddir/autoinstall.cfg" /etc/autoinstall.default
 }

--- a/dracut/autoinstaller/parse-vai-root.sh
+++ b/dracut/autoinstaller/parse-vai-root.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+if [ "${root}" = "vai" ] ; then
+    rootok=1
+fi


### PR DESCRIPTION
This fixes issues where network hardware may not have settled by the time that the installer is ready to use dhclient.  It also allows the installer to claim and validate the root filesystem mount, to suppress cases where dracut is unhappy with `/dev/null`.