### PR TITLE
mklive.sh: Redefining the behavior of `option -r <repo>`

### DIFF
--- a/mklive.sh
+++ b/mklive.sh
@@ -28,6 +28,13 @@ umask 022
 
 . ./lib.sh
 
+
+## Store `lib.sh / XBPS_REPOSITORY` to `DEFAULT_XBPS_REPOSITORY`
+DEFAULT_XBPS_REPOSITORY="${XBPS_REPOSITORY}"
+## Reset `XBPS_REPOSITORY` to `empty string`
+XBPS_REPOSITORY=""
+
+
 REQUIRED_PKGS=(base-files libgcc dash coreutils sed tar gawk squashfs-tools xorriso)
 TARGET_PKGS=(base-files)
 INITRAMFS_PKGS=(binutils xz device-mapper dhclient dracut-network openresolv)
@@ -528,7 +535,11 @@ while getopts "a:b:r:c:C:T:Kk:l:i:I:S:e:s:o:p:g:v:P:x:Vh" opt; do
 	esac
 done
 shift $((OPTIND - 1))
-XBPS_REPOSITORY="$XBPS_REPOSITORY --repository=https://repo-default.voidlinux.org/current --repository=https://repo-default.voidlinux.org/current/musl --repository=https://repo-default.voidlinux.org/current/aarch64"
+
+
+#XBPS_REPOSITORY="$XBPS_REPOSITORY --repository=https://repo-default.voidlinux.org/current --repository=https://repo-default.voidlinux.org/current/musl --repository=https://repo-default.voidlinux.org/current/aarch64"
+: ${XBPS_REPOSITORY:=${DEFAULT_XBPS_REPOSITORY}}
+
 
 # Configure dracut to use overlayfs for the writable overlay.
 BOOT_CMDLINE="$BOOT_CMDLINE rd.live.overlay.overlayfs=1 "


### PR DESCRIPTION


## Redefine

* `-r <repo>` will be recorded in XBPS_REPOSITORY.
* if not `-r <repo>`, using default repo. it is defined in [lib.sh](https://github.com/void-linux/void-mklive/blob/d37946fac99cd97c9557e04782b7c6a7df6f5ec4/lib.sh#L323-L325).
* if adding arguments `-r <repo>`, just using `-r <repo>`.
* arguments `-r <repo>` can be added multiple times.


## Example


### Example / 1

``` sh
sudo ./mklive.sh
```

> not -r, using default ==> rusult:

```
XBPS_REPOSITORY="--repository=https://repo-default.voidlinux.org/current --repository=https://repo-default.voidlinux.org/current/musl --repository=https://repo-default.voidlinux.org/current/aarch64"
```


### Example / 2

``` sh
sudo ./mklive.sh -r "https://repo-fastly.voidlinux.org/current"
```

> add one repo ==> rusult:

```
XBPS_REPOSITORY="--repository=https://repo-fastly.voidlinux.org/current"
```


### Example / 3

``` sh
sudo ./mklive.sh -r "https://repo-fastly.voidlinux.org/current" -r "https://repo-fi.voidlinux.org/current"
```

> add two repo ==> rusult:


```
XBPS_REPOSITORY="--repository=https://repo-fastly.voidlinux.org/current --repository=https://repo-fi.voidlinux.org/current"
```


## Link

* [Void Linux Mirrors](https://xmirror.voidlinux.org/)
