### PR TITLE
mklive.sh: Provide new option `-H <host_cachedir>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ OPTIONS
  -b <system-pkg>    Set an alternative base package (default: base-system)
  -r <repo>          Use this XBPS repository. May be specified multiple times
  -c <cachedir>      Use this XBPS cache directory (default: ./xbps-cachedir-<arch>)
+ -H <host_cachedir> Use this Host XBPS cache directory (default: ./xbps-cachedir-<host_arch>)
  -k <keymap>        Default keymap to use (default: us)
  -l <locale>        Default locale to use (default: en_US.UTF-8)
  -i <lz4|gzip|bzip2|xz>

--- a/mklive.sh
+++ b/mklive.sh
@@ -84,6 +84,7 @@ usage() {
 	 -b <system-pkg>    Set an alternative base package (default: base-system)
 	 -r <repo>          Use this XBPS repository. May be specified multiple times
 	 -c <cachedir>      Use this XBPS cache directory (default: ./xbps-cachedir-<arch>)
+	 -H <host_cachedir> Use this Host XBPS cache directory (default: ./xbps-cachedir-<host_arch>)
 	 -k <keymap>        Default keymap to use (default: us)
 	 -l <locale>        Default locale to use (default: en_US.UTF-8)
 	 -i <lz4|gzip|bzip2|xz>
@@ -500,12 +501,13 @@ generate_iso_image() {
 #
 # main()
 #
-while getopts "a:b:r:c:C:T:Kk:l:i:I:S:e:s:o:p:g:v:P:x:Vh" opt; do
+while getopts "a:b:r:H:c:C:T:Kk:l:i:I:S:e:s:o:p:g:v:P:x:Vh" opt; do
 	case $opt in
 		a) TARGET_ARCH="$OPTARG";;
 		b) BASE_SYSTEM_PKG="$OPTARG";;
 		r) XBPS_REPOSITORY="--repository=$OPTARG $XBPS_REPOSITORY";;
 		c) XBPS_CACHEDIR="$OPTARG";;
+		H) XBPS_HOST_CACHEDIR="$OPTARG";;
 		g) IGNORE_PKGS+=($OPTARG) ;;
 		K) readonly KEEP_BUILDDIR=1;;
 		k) KEYMAP="$OPTARG";;


### PR DESCRIPTION


## Define

* `-H <host_cachedir>` will be recorded in `XBPS_HOST_CACHEDIR`.
* if not `-H <host_cachedir>`, using default value `./xbps-cachedir-<host_arch>`
* if there are multiple -H options, the last option -H will be used.


## Example


### Example / 1

``` sh
sudo ./mklive.sh
```

> not `-H <host_cachedir>`, using default ==> rusult like:

```
XBPS_HOST_CACHEDIR=/home/anon/work/void-mklive/xbps-cachedir-x86_64
```


### Example / 2

``` sh
sudo ./mklive.sh -H "/var/cache/xbps"
```

> add `-H "/var/cache/xbps"`, ==> rusult :

```
XBPS_HOST_CACHEDIR=/var/cache/xbps
```


### Example / 3

``` sh
sudo ./mklive.sh -H "$(pwd)/pkg-cache"
```

> add `-H "$(pwd)/pkg-cache"`, ==> rusult like:

```
XBPS_HOST_CACHEDIR=/home/anon/work/void-mklive/pkg-cache
```


### Example / 4

``` sh
sudo ./mklive.sh -H "$(pwd)/pkg-cache" -H "/var/cache/xbps"
```

> add `-H "$(pwd)/pkg-cache" -H "/var/cache/xbps"`, ==> rusult:

```
XBPS_HOST_CACHEDIR=/var/cache/xbps
```

> the last option -H will be used.
