### PR TITLE
fix: correct language name for 'be' from "Belgian" to "Belarusian"

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -141,7 +141,7 @@ iso639_language() {
     an)  echo "Aragonese" ;;
     ar)  echo "Arabic" ;;
     ast) echo "Asturian" ;;
-    be)  echo "Belgian" ;;
+    be)  echo "Belarusian" ;;
     bg)  echo "Bulgarian" ;;
     bhb) echo "Bhili" ;;
     br)  echo "Breton" ;;


### PR DESCRIPTION
as per https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes