### PR TITLE
Fix dracut failure when loading system fs.

### DIFF
--- a/mklive.sh
+++ b/mklive.sh
@@ -435,14 +435,14 @@ EOF
 generate_squashfs() {
     umount_pseudofs || exit 1
 
-    # Find out required size for the rootfs and create an ext3fs image off it.
+    # Find out required size for the rootfs and create an rootfs image off it.
     ROOTFS_SIZE=$(du --apparent-size -sm "$ROOTFS"|awk '{print $1}')
     mkdir -p "$BUILDDIR/tmp/LiveOS"
     truncate -s "$((ROOTFS_SIZE+ROOTFS_SIZE))M" \
-	    "$BUILDDIR"/tmp/LiveOS/ext3fs.img >/dev/null 2>&1
+	    "$BUILDDIR"/tmp/LiveOS/rootfs.img >/dev/null 2>&1
     mkdir -p "$BUILDDIR/tmp-rootfs"
-    mkfs.ext3 -F -m1 "$BUILDDIR/tmp/LiveOS/ext3fs.img" >/dev/null 2>&1
-    mount -o loop "$BUILDDIR/tmp/LiveOS/ext3fs.img" "$BUILDDIR/tmp-rootfs"
+    mkfs.ext3 -F -m1 "$BUILDDIR/tmp/LiveOS/rootfs.img" >/dev/null 2>&1
+    mount -o loop "$BUILDDIR/tmp/LiveOS/rootfs.img" "$BUILDDIR/tmp-rootfs"
     cp -a "$ROOTFS"/* "$BUILDDIR"/tmp-rootfs/
     umount -f "$BUILDDIR/tmp-rootfs"
     mkdir -p "$IMAGEDIR/LiveOS"


### PR DESCRIPTION
> https://github.com/dracut-ng/dracut/commit/bbd26137bd3289c9ea1766116afc125ead7b82b3
> chore(dmsquash-live): remove support for ext3fs.img All dracut based live iso's use either squashfs.img (compressed live) or rootfs.img (uncompressed live).
> Remove support for ext3fs.img.
<img width="1083" height="354" alt="image" src="https://github.com/user-attachments/assets/b61a768e-3622-41bf-8f44-4e105eac637b" />


```
/init: 9: /var/lib/dracut/hooks/pre-pivot/01-adduser.sh: cannot create /sysroot/
/init: 19: /var/lib/dracut/hooks/pre-pivot/01-adduser.sh: cannot create /sysroot/
chmod: cannot access '/sysroot/etc/default/live.conf': No such file or directory
grep: /sysroot/etc/shells: No such file or directory
/init: 23: /var/lib/dracut/hooks/pre-pivot/01-adduser.sh: cannot create /sysroot/
chroot: failed to run command '/bin/sh': No such file or directory
chroot: failed to run command 'useradd': No such file or directory
chroot: failed to run command 'sh': No such file or directory
chroot: failed to run command 'sh': No such file or directory
/init: 11: /var/lib/dracut/hooks/pre-pivot/03-locale.sh: cannot create /sysroot/
/init: 12: /var/lib/dracut/hooks/pre-pivot/03-locale.sh: cannot create /sysroot/
dracut Warning: Kernel command line option 'rd.live.overlay.overlayfs' is deprec
Cannot find init!
Please check to make sure you passed a valid root filesystem!

dracut Warning: 

Generating "/run/initramfs/rdsosreport.txt"
[    8.954837] I/O error, dev fd0, sector 0 op 0x0:(READ) flags 0x0 phys_seg 1 p
You might want to save "/run/initramfs/rdsosreport.txt" to a USB stick or /boot
after mounting them and attach it to a bug report.

To get more debug information in the report,
reboot with "rd.debug" added to the kernel command line.

Dropping to debug shell.

dracut:/#
```

Due to the dracut package being updated, you need to rename ext3fs.img to rootfs.img to avoid issues.

You can keep using mkfs.ext3 without any issues; just change the name of the img file so it works.

